### PR TITLE
gh #110 Code Cleanup of dsHdmiIn

### DIFF
--- a/src/test_l1_dsHdmiIn.c
+++ b/src/test_l1_dsHdmiIn.c
@@ -1558,13 +1558,13 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
     if (gSourceType == 0) {
         // step 2 to Step 3: validating dsIsHdmiARCPort with valid Input and compare the Results
         for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
-             result = dsIsHdmiARCPort(port, &PortResult1);
-             UT_ASSERT_EQUAL(result, dsERR_NONE);
+            result = dsIsHdmiARCPort(port, &PortResult1);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-             result = dsIsHdmiARCPort(port, &PortResult2);
-             UT_ASSERT_EQUAL(result, dsERR_NONE);
+            result = dsIsHdmiARCPort(port, &PortResult2);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-             UT_ASSERT_EQUAL(PortResult1, PortResult2);
+            UT_ASSERT_EQUAL(PortResult1, PortResult2);
         }
 
     } else if (gSourceType == 1) {
@@ -1984,7 +1984,7 @@ void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
 
             UT_ASSERT_EQUAL(edid_version_1, edid_version_2);
 
-       }
+        }
     } else if (gSourceType == 1) {
        // Step 4: Call dsGetEdidVersion() with valid ports
        UT_ASSERT_EQUAL(dsGetEdidVersion(dsHDMI_IN_PORT_0, &edid_version_1), dsERR_OPERATION_NOT_SUPPORTED);

--- a/src/test_l1_dsHdmiIn.c
+++ b/src/test_l1_dsHdmiIn.c
@@ -278,7 +278,6 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetNumberOfInputs(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
         // Step 2: Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports
@@ -494,10 +493,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
        }
     } else {
 
-	for (uint8_t i =  numInputPorts; i < dsHDMI_IN_PORT_MAX; i++)
+        for (uint8_t i =  numInputPorts; i < dsHDMI_IN_PORT_MAX; i++)
         {
              // Step 5: Call dsHdmiInSelectPort()
-    	     UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_OPERATION_NOT_SUPPORTED);
+             UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_OPERATION_NOT_SUPPORTED);
         }
     }
 
@@ -545,17 +544,17 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     for (uint8_t i = dsHDMI_IN_PORT_0; i < numInputPorts; i++)
     {
-	  // Step 4: Call dsHdmiInSelectPort() with an invalid value
+	  // Step 3: Call dsHdmiInSelectPort() with an invalid value
           UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_INVALID_PARAM);
 
-          // Step 5: Call dsHdmiInSelectPort() with an invalid plane value
+          // Step 4: Call dsHdmiInSelectPort() with an invalid plane value
           UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_MAX, false), dsERR_INVALID_PARAM);
     }
 
-    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    // Step 7: Call dsHdmiInSelectPort() after terminating the HDMI input sub-system
+    // Step 6: Call dsHdmiInSelectPort() after terminating the HDMI input sub-system
     result = dsHdmiInSelectPort(dsHDMI_IN_PORT_0, false, dsVideoPlane_PRIMARY, false);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_INVALID_PARAM);
 
@@ -795,10 +794,9 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source(void) {
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode() |dsVideoPortResolution_t*| dsERR_NONE | Video mode should be retrieved |
- * |03|Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode() |dsVideoPortResolution_t*| dsERR_NONE | Video mode should be retrieved |
- * |04|Ensure returned values are the same| |Success| The values should be the same |
- * |05|dsHdmiInGetCurrentVideoMode() to get the current HDMI input video mode of the active port | dsERR_OPERATION_NOT_SUPPORTED| For source devices without HDMI input support
- * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |03|Ensure returned values are the same| |Success| The values should be the same |
+ * |04|dsHdmiInGetCurrentVideoMode() to get the current HDMI input video mode of the active port | dsERR_OPERATION_NOT_SUPPORTED| For source devices without HDMI input support
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
@@ -920,11 +918,11 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterConnectCB(void) {
     // Step 2: Call dsHdmiInRegisterConnectCB() based on the number of input ports
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-    	 // For sink devices
+         // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterConnectCB(mockConnectCallback), dsERR_NONE);
     } else {
-    	// For source devices
-    	UT_ASSERT_EQUAL(dsHdmiInRegisterConnectCB(mockConnectCallback), dsERR_OPERATION_NOT_SUPPORTED);
+        // For source devices
+        UT_ASSERT_EQUAL(dsHdmiInRegisterConnectCB(mockConnectCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
@@ -1010,8 +1008,8 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterSignalChangeCB(void) {
 
     // Step 2: Call dsHdmiInRegisterSignalChangeCB() based on the device type
     if (gSourceType == 0) {
-    	// For sink devices
-    	UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_NONE);
+        // For sink devices
+        UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_NONE);
 
     } else if (gSourceType == 1) {
     	// For source devices
@@ -1101,7 +1099,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterStatusChangeCB(void) {
 
     // Step 2: Call dsHdmiInRegisterStatusChangeCB() based on the number of input ports
     if (gSourceType == 0) {
-    	// For sink devices
+        // For sink devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterStatusChangeCB(mockStatusChangeCallback), dsERR_NONE);
     } else if (gSourceType == 1) {
         // For source devices
@@ -1537,13 +1535,10 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAviContentTypeChangeCB(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_0, bool*| dsERR_NONE | Should successfully check for ARC capability |
- * |04|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_1, bool*| dsERR_NONE | Should successfully check for ARC capability |
- * |05|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_2, bool*| dsERR_NONE | Should successfully check for ARC capability |
- * |06|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_2, bool*| dsERR_NONE | Should successfully check for ARC capability |
- * |07|Compare the values of steps 4 and 5 to make sure they equal one another || Success | The values should be equal |
- * |08|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_0, bool*| dsERR_OPERATION_NOT_SUPPORTED | for source devices
- * |09|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsIsHdmiARCPort() with valid ports |[Valid Port], bool*| dsERR_NONE | Should successfully check for ARC capability |
+ * |03|Compare the values of steps 2 to make sure they equal one another || Success | The values should be equal |
+ * |04|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_0, bool*| dsERR_OPERATION_NOT_SUPPORTED | for source devices
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
@@ -1560,26 +1555,24 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Check if HDMI ARC is supported based on the device type
     if (gSourceType == 0) {
-
-        // step 3 to 7: validating dsIsHdmiARCPort with valid Input and compare the Results
+        // step 2 to Step 3: validating dsIsHdmiARCPort with valid Input and compare the Results
         for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
-            result = dsIsHdmiARCPort(port, &PortResult1);
-            UT_ASSERT_EQUAL(result, dsERR_NONE);
+             result = dsIsHdmiARCPort(port, &PortResult1);
+             UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-            result = dsIsHdmiARCPort(port, &PortResult2);
-            UT_ASSERT_EQUAL(result, dsERR_NONE);
+             result = dsIsHdmiARCPort(port, &PortResult2);
+             UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-            UT_ASSERT_EQUAL(PortResult1, PortResult2);
+             UT_ASSERT_EQUAL(PortResult1, PortResult2);
         }
 
     } else if (gSourceType == 1) {
-        // Step 8:Call dsIsHdmiARCPort() with valid input for source devices
+        // Step 4:Call dsIsHdmiARCPort() with valid input for source devices
         UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_0, &PortResult1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 9: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -1649,13 +1642,10 @@ void test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_0, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
- * |03|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_1, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
- * |04|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_2, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
- * |05|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_2, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
- * |06|Compare the results and make sure they are the same | | Success | The values should be the same |
- * |07|Call dsGetEDIDBytesInfo() with valid input |dsHDMI_IN_PORT_0, unsigned char*, int*| dsERR_OPERATION_NOT_SUPPORTED| For source devices
- * |08|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsGetEDIDBytesInfo() with valid ports |[Valid Port], unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
+ * |03|Compare the retrieved EDID bytes for each port and ensure they are identical| Success | The values should be the same |
+ * |04|Call dsGetEDIDBytesInfo() with valid input |dsHDMI_IN_PORT_0, unsigned char*, int*| dsERR_OPERATION_NOT_SUPPORTED| For source devices
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
@@ -1672,22 +1662,21 @@ void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     if (gSourceType == 0) {
-        // Step 3 to Step 7
+        // Step 2 to Step 3: Retrieve EDID bytes information for each HDMI input port and compare results
         for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
             UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(port, edidBytes1, &edidSize1), dsERR_NONE);
 
             UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(port, edidBytes2, &edidSize2), dsERR_NONE);
 
-            // Compare the results and make sure they are the same
             UT_ASSERT_EQUAL(edidSize1, edidSize2);
             UT_ASSERT_EQUAL(memcmp(edidBytes1, edidBytes2, edidSize1),0);
         }
     } else if (gSourceType == 1) {
-        // Step 8: Call dsGetEDIDBytesInfo() with valid input for source devices
+        // Step 4: Call dsGetEDIDBytesInfo() with valid input for source devices
         UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(dsHDMI_IN_PORT_0, edidBytes1, &edidSize1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 9: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -1763,13 +1752,10 @@ void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_0, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
- * |03|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_1, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
- * |04|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_2, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
- * |05|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_2, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
- * |06|Compare values from step 4/5 and make sure they're the same || Success | The values should be the same |
- * |07|Call dsGetHDMISPDInfo() with valid input | dsHDMI_IN_PORT_0, unsigned char* | dsERR_OPERATION_NOT_SUPPORTED | For source devices
- * |08|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsGetHDMISPDInfo() with valid input |[Valid Port], unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
+ * |03|Compare values from step 2 and make sure they're the same || Success | The values should be the same |
+ * |04|Call dsGetHDMISPDInfo() with valid input | dsHDMI_IN_PORT_0, unsigned char* | dsERR_OPERATION_NOT_SUPPORTED | For source devices
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
@@ -1784,24 +1770,21 @@ void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     if (gSourceType == 0) {
-        // Step 3 to Step 7
+        // Step 2 to Step 3: Retrieve HDMI SPD information for each HDMI input port and compare results
         for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
 
-            // Step 3: Call dsGetHDMISPDInfo() with valid input (dsHDMI_IN_PORT_0)
             UT_ASSERT_EQUAL(dsGetHDMISPDInfo(port, spdInfo1), dsERR_NONE);
 
-            // Step 4: Call dsGetHDMISPDInfo() with valid input (dsHDMI_IN_PORT_1)
             UT_ASSERT_EQUAL(dsGetHDMISPDInfo(port, spdInfo2), dsERR_NONE);
 
-            // Step 7: Compare the results and make sure they are the same
             UT_ASSERT_EQUAL(memcmp(spdInfo1, spdInfo2,sizeof(struct dsSpd_infoframe_st)),0);
         }
     } else if (gSourceType == 1) {
-        // Step 8: Call dsGetHDMISPDInfo() with valid input for source devices
+        // Step 4: Call dsGetHDMISPDInfo() with valid input for source devices
         UT_ASSERT_EQUAL(dsGetHDMISPDInfo(dsHDMI_IN_PORT_0, spdInfo1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 9: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -1891,8 +1874,7 @@ void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     if (gSourceType == 0) {
-	 
-	for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
               // Step 2: Call dsSetEdidVersion() with valid values for each port and each EDID version
               UT_ASSERT_EQUAL(dsSetEdidVersion(port, ver14), dsERR_NONE);
               UT_ASSERT_EQUAL(dsSetEdidVersion(port, ver20), dsERR_NONE);
@@ -1992,7 +1974,7 @@ void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     if (gSourceType == 0) {
-       // Step 3: Call dsGetEdidVersion() with valid values (dsHDMI_IN_PORT_0, tv_hdmi_edid_version_t*)
+       // Step 2 to Step 3: Call dsGetEdidVersion() with valid values (dsHDMI_IN_PORT_0, tv_hdmi_edid_version_t*)
        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
             result = dsGetEdidVersion(port, &edid_version_1);
             UT_ASSERT_EQUAL(result, dsERR_NONE);
@@ -2000,15 +1982,15 @@ void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
             result = dsGetEdidVersion(port, &edid_version_2);
             UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-            UT_ASSERT_EQUAL(&edid_version_1, &edid_version_2);
-     
-      }
+            UT_ASSERT_EQUAL(edid_version_1, edid_version_2);
+
+       }
     } else if (gSourceType == 1) {
-       // Step 5: Call dsGetEdidVersion() with valid ports
+       // Step 4: Call dsGetEdidVersion() with valid ports
        UT_ASSERT_EQUAL(dsGetEdidVersion(dsHDMI_IN_PORT_0, &edid_version_1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -2096,16 +2078,15 @@ void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     if (gSourceType == 0) {
+        // Step 2: Call dsGetAllmStatus() with valid inputs
+        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+             result = dsGetAllmStatus(port, &allm_status_1);
+             UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-	   // Step 2: Call dsGetAllmStatus() with valid inputs
-	   for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
-           result = dsGetAllmStatus(port, &allm_status_1);
-           UT_ASSERT_EQUAL(result, dsERR_NONE);
+             result = dsGetAllmStatus(port, &allm_status_2);
+             UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-            result = dsGetAllmStatus(port, &allm_status_2);
-            UT_ASSERT_EQUAL(result, dsERR_NONE);
-
-            UT_ASSERT_EQUAL(allm_status_1, allm_status_2);
+             UT_ASSERT_EQUAL(allm_status_1, allm_status_2);
         }
 
     } else if (gSourceType == 1) {
@@ -2293,7 +2274,6 @@ void test_l1_dsHdmiIn_positive_dsGetAVLatency_sink(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-
     if (gSourceType == 0) {
         // Step 2: Call dsHdmiInSelectPort() to select Port 0
         UT_ASSERT_EQUAL(dsHdmiInSelectPort(dsHDMI_IN_PORT_0, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
@@ -2387,18 +2367,28 @@ void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
     gTestID = 47;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
+    dsError_t  result = dsERR_NONE;
+    uint8_t numInputPorts = 0;
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize HDMI input using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     if (gSourceType == 0) {
         // Step 2: Call dsSetEdid2AllmSupport() with all valid ports and enable EDID ALLM support
-        UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, true), dsERR_NONE);
-        UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_1, true), dsERR_NONE);
-        UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_2, true), dsERR_NONE);
+        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++)
+        {
+              result = dsSetEdid2AllmSupport(port, true);
+              UT_ASSERT_EQUAL(result, dsERR_NONE);
+        }
 
         // Step 3: Call dsSetEdid2AllmSupport() to disable EDID ALLM support
-        UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, false), dsERR_NONE);
+        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++)
+        {
+              result = dsSetEdid2AllmSupport(port, false);
+              UT_ASSERT_EQUAL(result, dsERR_NONE);
+        }
+
     } else if (gSourceType == 1) {
         // Step 4:Call dsSetEdid2AllmSupport() with valid ports
         UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, true), dsERR_OPERATION_NOT_SUPPORTED);
@@ -2491,11 +2481,10 @@ void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
     // Step 1: Initialize HDMI input using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-
     if (gSourceType == 0) {
 
         // Step 2 to 3: Call dsGetEdid2AllmSupport() to verify EDID ALLM support
-	for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
             result = dsGetEdid2AllmSupport(port, &allmSupport1);
             UT_ASSERT_EQUAL(result, dsERR_NONE);
 

--- a/src/test_l1_dsHdmiIn.c
+++ b/src/test_l1_dsHdmiIn.c
@@ -262,7 +262,6 @@ void test_l1_dsHdmiIn_negative_dsHdmiInTerm(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
  * |02|Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports |pNumberOfinputs: uint8_t*| dsERR_NONE | Number should be between 0 and max number of inputs defined in dsHdmiInPort_t |
  * |03|Retrieve the expected number of HDMI input ports from the profile file and compare it with the number obtained from dsHdmiInGetNumberOfInputs() |
  * |04|Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports |dsERR_OPERATION_NOT_SUPPORTED |For source devices without HDMI input support | 
@@ -279,20 +278,20 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetNumberOfInputs(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
+
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-        // Step 3: Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports
+        // Step 2: Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports
         UT_ASSERT_EQUAL(dsHdmiInGetNumberOfInputs(&numInputs), dsERR_NONE);
 
-        // Step 4: Verify that the number of HDMI input ports obtained matches the expected value from the profile
+        // Step 3: Verify that the number of HDMI input ports obtained matches the expected value from the profile
         UT_ASSERT_KVP_EQUAL_PROFILE_UINT8(numInputs, "dsHdmiIn/HdmiInputPort/numberOfPorts");
     } else {
-       // Step 5: For source devices without HDMI input support
+       // Step 4: For source devices without HDMI input support
        UT_ASSERT_EQUAL(dsHdmiInGetNumberOfInputs(&numInputs), 0);
     }
 
-    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -358,12 +357,11 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetNumberOfInputs(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
+ * |02|Call dsHdmiInGetStatus() with valid pointer |dsHdmiInStatus_t*| dsERR_NONE | Status information should be populated. Validate the output structure |
  * |03|Call dsHdmiInGetStatus() with valid pointer |dsHdmiInStatus_t*| dsERR_NONE | Status information should be populated. Validate the output structure |
- * |04|Call dsHdmiInGetStatus() with valid pointer |dsHdmiInStatus_t*| dsERR_NONE | Status information should be populated. Validate the output structure |
- * |05|Compare the returned values to make sure they are equal || Success | The values should be the same |
- * |06|Call dsHdmiInGetStatus() with valid pointer |dsHdmiInStatus_t*| dsERR_OPERATION_NOT_SUPPORTED | For source devices without HDMI input support |
- * |07|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |04|Compare the returned values to make sure they are equal || Success | The values should be the same |
+ * |05|Call dsHdmiInGetStatus() with valid pointer |dsHdmiInStatus_t*| dsERR_OPERATION_NOT_SUPPORTED | For source devices without HDMI input support |
+ * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
@@ -376,16 +374,15 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-        // Step 3: Call dsHdmiInGetStatus()
+        // Step 2: Call dsHdmiInGetStatus()
         UT_ASSERT_EQUAL(dsHdmiInGetStatus(&status1), dsERR_NONE);
 
-        // Step 4: Call dsHdmiInGetStatus() again
+        // Step 3: Call dsHdmiInGetStatus() again
         UT_ASSERT_EQUAL(dsHdmiInGetStatus(&status2), dsERR_NONE);
 
-        // Step 5: Compare the returned values to make sure they are equal
+        // Step 4: Compare the returned values to make sure they are equal
         UT_ASSERT_EQUAL(status1.isPresented, status2.isPresented);
         UT_ASSERT_EQUAL(status1.activePort, status2.activePort);
         for (int i = 0; i < dsHDMI_IN_PORT_MAX; i++) {
@@ -395,11 +392,11 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
              UT_ASSERT_EQUAL(status1.isPortConnected[i], status2.isPortConnected[i]);
         }
     } else {
-      // Step 6: For source devices without hdmi input support
+      // Step 5: For source devices without hdmi input support
       UT_ASSERT_EQUAL(dsHdmiInGetStatus(&status1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 7: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -465,12 +462,11 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetStatus(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool false| dsERR_NONE | Port 0 should be selected |
- * |04|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_1, bool: true, dsVideoPlane_SECONDARY, bool true| dsERR_NONE | Port 1 should be selected |
- * |05|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_2, bool: false, dsVideoPlane_PRIMARY, bool false| dsERR_NONE | Port 2 should be selected |
- * |06||Call dsHdmiInSelectPort() | dsERR_OPERATION_NOT_SUPPORTED | Loop through the ports where HDMI input is not supported
- * |07|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool false| dsERR_NONE | Port 0 should be selected |
+ * |03|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_1, bool: true, dsVideoPlane_SECONDARY, bool true| dsERR_NONE | Port 1 should be selected |
+ * |04|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_2, bool: false, dsVideoPlane_PRIMARY, bool false| dsERR_NONE | Port 2 should be selected |
+ * |05||Call dsHdmiInSelectPort() | dsERR_OPERATION_NOT_SUPPORTED | Loop through the ports where HDMI input is not supported
+ * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
@@ -482,31 +478,30 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
 
         for (uint8_t i = dsHDMI_IN_PORT_0; i < numInputPorts; i++)
         {
-             // Step 3: Call dsHdmiInSelectPort() to select Port 0
+             // Step 2: Call dsHdmiInSelectPort() to select Port 0
              UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
 
-             // Step 4: Call dsHdmiInSelectPort() to select Port 1
+             // Step 3: Call dsHdmiInSelectPort() to select Port 1
              UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, true, dsVideoPlane_SECONDARY, true), dsERR_NONE);
 
-             // Step 5: Call dsHdmiInSelectPort() to select Port 2
+             // Step 4: Call dsHdmiInSelectPort() to select Port 2
              UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
        }
     } else {
 
 	for (uint8_t i =  numInputPorts; i < dsHDMI_IN_PORT_MAX; i++)
         {
-             // Step 6: Call dsHdmiInSelectPort()
+             // Step 5: Call dsHdmiInSelectPort()
     	     UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_OPERATION_NOT_SUPPORTED);
         }
     }
 
-    // Step 7: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -526,11 +521,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
  * |:--:|-----------|----------|--------------|-----|
  * |01|Call dsHdmiInSelectPort() without initializing the HDMI input sub-system |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool: false| dsERR_NOT_INITIALIZED | Should Pass |
  * |02|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |03|Get the number of input ports from the profile file
- * |04|Call dsHdmiInSelectPort() with invalid value |dsHDMI_IN_PORT_MAX, bool: false, dsVideoPlane_PRIMARY, bool: false| dsERR_INVALID_PARAM | Should Pass |
- * |05|Call dsHdmiInSelectPort() with invalid plane value |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_MAX, bool: true| dsERR_INVALID_PARAM | Should Pass |
- * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * |07|Call dsHdmiInSelectPort() after terminating the HDMI input sub-system |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool: false| dsERR_NOT_INITIALIZED | Should Pass |
+ * |03|Call dsHdmiInSelectPort() with invalid value |dsHDMI_IN_PORT_MAX, bool: false, dsVideoPlane_PRIMARY, bool: false| dsERR_INVALID_PARAM | Should Pass |
+ * |04|Call dsHdmiInSelectPort() with invalid plane value |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_MAX, bool: true| dsERR_INVALID_PARAM | Should Pass |
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |06|Call dsHdmiInSelectPort() after terminating the HDMI input sub-system |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool: false| dsERR_NOT_INITIALIZED | Should Pass |
  *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
  *
@@ -548,7 +542,6 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
     // Step 2: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 3: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     for (uint8_t i = dsHDMI_IN_PORT_0; i < numInputPorts; i++)
     {
@@ -582,12 +575,11 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Scale HDMI input video using dsHdmiInScaleVideo() |x=0, y=0, width=800, height=600| dsERR_NONE | Video should be scaled |
- * |04|Scale HDMI input video using dsHdmiInScaleVideo() |x=10, y=10, width=1000, height=800| dsERR_NONE | Video should be scaled |
- * |05|Scale HDMI input video using dsHdmiInScaleVideo() |x=100, y=100, width=800, height=600| dsERR_NONE | Video should be scaled |
- * |06|Scale HDMI input video using dsHdmiInScaleVideo() |x=0, y=0, width=800, height=600| dsERR_OPERATION_NOT_SUPPORTED | For source devices without HDMI input support |
- * |07|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Scale HDMI input video using dsHdmiInScaleVideo() |x=0, y=0, width=800, height=600| dsERR_NONE | Video should be scaled |
+ * |03|Scale HDMI input video using dsHdmiInScaleVideo() |x=10, y=10, width=1000, height=800| dsERR_NONE | Video should be scaled |
+ * |04|Scale HDMI input video using dsHdmiInScaleVideo() |x=100, y=100, width=800, height=600| dsERR_NONE | Video should be scaled |
+ * |05|Scale HDMI input video using dsHdmiInScaleVideo() |x=0, y=0, width=800, height=600| dsERR_OPERATION_NOT_SUPPORTED | For source devices without HDMI input support |
+ * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInScaleVideo(void) {
@@ -599,23 +591,22 @@ void test_l1_dsHdmiIn_positive_dsHdmiInScaleVideo(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-        // Step 3: Scale HDMI input video (x=0, y=0, width=800, height=600)
+        // Step 2: Scale HDMI input video (x=0, y=0, width=800, height=600)
         UT_ASSERT_EQUAL(dsHdmiInScaleVideo(0, 0, 800, 600), dsERR_NONE);
 
-       // Step 4: Scale HDMI input video (x=10, y=10, width=1000, height=800)
+       // Step 3: Scale HDMI input video (x=10, y=10, width=1000, height=800)
        UT_ASSERT_EQUAL(dsHdmiInScaleVideo(10, 10, 1000, 800), dsERR_NONE);
 
-       // Step 5: Scale HDMI input video (x=-10, y=-10, width=800, height=600)
+       // Step 4: Scale HDMI input video (x=-10, y=-10, width=800, height=600)
        UT_ASSERT_EQUAL(dsHdmiInScaleVideo(100, 100, 800, 600), dsERR_NONE);
     } else {
-      // Step 6: For source devices without hdmi input support
+      // Step 5: For source devices without hdmi input support
       UT_ASSERT_EQUAL(dsHdmiInScaleVideo(0, 0, 800, 600), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 7: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -704,11 +695,10 @@ void test_l1_dsHdmiIn_negative_dsHdmiInScaleVideo(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool false| dsERR_NONE | Port 0 should be selected |
- * |04|Call dsHdmiInSelectZoomMode() and loop through all valid dsVideoZoom_t |[Valid Zoom Mode]| dsERR_NONE | Zoom mode should be updated |
- * |05|Call dsHdmiInSelectZoomMode() updates the video zoom on the active HDMI input using the provided zoom |dsERR_OPERATION_NOT_SUPPORTED |For both sink and source devices without HDMI input support
- * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool false| dsERR_NONE | Port 0 should be selected |
+ * |03|Call dsHdmiInSelectZoomMode() and loop through all valid dsVideoZoom_t |[Valid Zoom Mode]| dsERR_NONE | Zoom mode should be updated |
+ * |04|Call dsHdmiInSelectZoomMode() updates the video zoom on the active HDMI input using the provided zoom |dsERR_OPERATION_NOT_SUPPORTED |For both sink and source devices without HDMI input support
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
@@ -720,23 +710,22 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-        // Step 3: Call dsHdmiInSelectPort() to select Port 0
+        // Step 2: Call dsHdmiInSelectPort() to select Port 0
         UT_ASSERT_EQUAL(dsHdmiInSelectPort(dsHDMI_IN_PORT_0, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
 
-        // Step 4: Loop through all dsVideoZoom_t values and call dsHdmiInSelectZoomMode()
+        // Step 3: Loop through all dsVideoZoom_t values and call dsHdmiInSelectZoomMode()
         for (int i = dsVIDEO_ZOOM_NONE; i < dsVIDEO_ZOOM_MAX; i++) {
               dsVideoZoom_t zoomMode = i;
               UT_ASSERT_EQUAL(dsHdmiInSelectZoomMode(zoomMode), dsERR_NONE);
         }
     } else {
-       // Step 5:Calling dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_MAX)
+       // Step 4:Calling dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_MAX)
        UT_ASSERT_EQUAL(dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_MAX), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -805,12 +794,11 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
+ * |02|Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode() |dsVideoPortResolution_t*| dsERR_NONE | Video mode should be retrieved |
  * |03|Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode() |dsVideoPortResolution_t*| dsERR_NONE | Video mode should be retrieved |
- * |04|Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode() |dsVideoPortResolution_t*| dsERR_NONE | Video mode should be retrieved |
- * |05|Ensure returned values are the same| |Success| The values should be the same |
- * |06|dsHdmiInGetCurrentVideoMode() to get the current HDMI input video mode of the active port | dsERR_OPERATION_NOT_SUPPORTED| For source devices without HDMI input support
- * |07|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |04|Ensure returned values are the same| |Success| The values should be the same |
+ * |05|dsHdmiInGetCurrentVideoMode() to get the current HDMI input video mode of the active port | dsERR_OPERATION_NOT_SUPPORTED| For source devices without HDMI input support
+ * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
@@ -824,14 +812,13 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-    	// Step 3: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
+    	// Step 2: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
         UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(&resolution1), dsERR_NONE);
         UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(&resolution2), dsERR_NONE);
 
-        // Step 4: Ensure returned values are the same
+        // Step 3: Ensure returned values are the same
         UT_LOG("\n In %s Name: [%d,%d]\n", __FUNCTION__, resolution1.name, resolution2.name);
         UT_ASSERT_EQUAL(resolution1.name, resolution2.name);
         UT_LOG("\n In %s pixelResolution: [%d,%d]\n", __FUNCTION__, resolution1.pixelResolution, resolution2.pixelResolution);
@@ -843,11 +830,11 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
         UT_LOG("\n In %s interlaced: [%d,%d]\n", __FUNCTION__, resolution1.interlaced, resolution2.interlaced);
         UT_ASSERT_EQUAL(resolution1.interlaced, resolution2.interlaced);
     } else {
-      // Step 6: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
+      // Step 4: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
       UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(&resolution1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 7: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -1009,7 +996,7 @@ void mockSignalCallback(dsHdmiInPort_t port, dsHdmiInSignalStatus_t sigStatus){
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsHdmiInRegisterSignalChangeCB() based on the number of input ports from the profile file |dsHdmiInSignalChangeCB_t| dsERR_NONE | Callback should be registered |
+ * |02|Call dsHdmiInRegisterSignalChangeCB() based on the device type|dsHdmiInSignalChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
@@ -1017,19 +1004,16 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterSignalChangeCB(void) {
 
     gTestID = 19;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t numInputPorts = 0;
-
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterSignalChangeCB() based on the number of input ports
-    if (numInputPorts > 0) {
+    // Step 2: Call dsHdmiInRegisterSignalChangeCB() based on the device type
+    if (gSourceType == 0) {
     	// For sink devices
     	UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_NONE);
 
-    } else {
+    } else if (gSourceType == 1) {
     	// For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
@@ -1103,7 +1087,7 @@ void mockStatusChangeCallback(dsHdmiInStatus_t inputStatus){
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsHdmiInRegisterStatusChangeCB() based on the number of input ports from the profile file |dsHdmiInStatusChangeCB_t| dsERR_NONE | Callback should be registered |
+ * |02|Call dsHdmiInRegisterStatusChangeCB() based on the device type |dsHdmiInStatusChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
@@ -1111,18 +1095,15 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterStatusChangeCB(void) {
 
     gTestID = 21;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t numInputPorts = 0;
-
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     // Step 2: Call dsHdmiInRegisterStatusChangeCB() based on the number of input ports
-    if (numInputPorts > 0) {
+    if (gSourceType == 0) {
     	// For sink devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterStatusChangeCB(mockStatusChangeCallback), dsERR_NONE);
-    } else {
+    } else if (gSourceType == 1) {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterStatusChangeCB(mockStatusChangeCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
@@ -1196,7 +1177,7 @@ void mockVideoModeUpdateCallback(dsHdmiInPort_t port, dsVideoPortResolution_t vi
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsHdmiInRegisterVideoModeUpdateCB() based on the number of input ports from the profile file |dsHdmiInVideoModeUpdateCB_t| dsERR_NONE | Callback should be registered |
+ * |02|Call dsHdmiInRegisterVideoModeUpdateCB() based on the device type |dsHdmiInVideoModeUpdateCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
@@ -1204,19 +1185,16 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterVideoModeUpdateCB(void) {
 
     gTestID = 23;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t numInputPorts = 0;
-
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterVideoModeUpdateCB() based on the number of input ports
-    if (numInputPorts > 0) {
+    // Step 2: Call dsHdmiInRegisterVideoModeUpdateCB() based on the device type
+    if (gSourceType == 0) {
         // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterVideoModeUpdateCB(mockVideoModeUpdateCallback), dsERR_NONE);
 
-    } else {
+    } else if (gSourceType == 1) {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterVideoModeUpdateCB(mockVideoModeUpdateCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
@@ -1290,7 +1268,7 @@ void mockALLMChangeCallback(dsHdmiInPort_t port, bool allm_mode){
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsHdmiInRegisterAllmChangeCB() based on the number of input ports from the profile file |dsHdmiInAllmChangeCB_t| dsERR_NONE | Callback should be registered |
+ * |02|Call dsHdmiInRegisterAllmChangeCB() based on the device type |dsHdmiInAllmChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
@@ -1298,19 +1276,16 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAllmChangeCB(void) {
 
     gTestID = 25;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t numInputPorts = 0;
-
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterAllmChangeCB() based on the number of input ports
-    if (numInputPorts > 0) {
+    // Step 2: Call dsHdmiInRegisterAllmChangeCB() based on the device type
+    if (gSourceType == 0) {
         // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterAllmChangeCB(mockALLMChangeCallback), dsERR_NONE);
 
-    } else {
+    } else if (gSourceType == 1) {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterAllmChangeCB(mockALLMChangeCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
@@ -1384,7 +1359,7 @@ void mockLatencyChangeCallback(int audio_latency, int video_latency){
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsHdmiInRegisterAVLatencyChangeCB() based on the number of input ports from the profile file |dsAVLatencyChangeCB_t| dsERR_NONE | Callback should be registered |
+ * |02|Call dsHdmiInRegisterAVLatencyChangeCB() based on the device type |dsAVLatencyChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
@@ -1392,19 +1367,16 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAVLatencyChangeCB(void) {
 
     gTestID = 27;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t numInputPorts = 0;
-
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterAVLatencyChangeCB() based on the number of input ports
-    if (numInputPorts > 0) {
+    // Step 2: Call dsHdmiInRegisterAVLatencyChangeCB() based on the device type
+    if (gSourceType == 0) {
         // For sink devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterAVLatencyChangeCB(mockLatencyChangeCallback), dsERR_NONE);
 
-    } else {
+    } else if (gSourceType == 1) {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterAVLatencyChangeCB(mockLatencyChangeCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
@@ -1478,7 +1450,7 @@ void mockAviContentCallback(dsHdmiInPort_t port, dsAviContentType_t avi_content_
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Call dsHdmiInRegisterAviContentTypeChangeCB() based on the number of input ports from the profile file |dsHdmiInAviContentTypeChangeCB_t| dsERR_NONE | Callback should be registered |
+ * |02|Call dsHdmiInRegisterAviContentTypeChangeCB() based on the device type|dsHdmiInAviContentTypeChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
@@ -1486,19 +1458,16 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAviContentTypeChangeCB(void) {
 
     gTestID = 29;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t numInputPorts = 0;
-
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterAviContentTypeChangeCB() based on the number of input ports
-    if (numInputPorts > 0) {
+    // Step 2: Call dsHdmiInRegisterAviContentTypeChangeCB() based on the device type
+    if (gSourceType == 0) {
         // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterAviContentTypeChangeCB(mockAviContentCallback), dsERR_NONE);
 
-    } else {
+    } else if (gSourceType == 1) {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterAviContentTypeChangeCB(mockAviContentCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
@@ -1568,8 +1537,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAviContentTypeChangeCB(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_0, bool*| dsERR_NONE | Should successfully check for ARC capability |
+ * |02|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_0, bool*| dsERR_NONE | Should successfully check for ARC capability |
  * |04|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_1, bool*| dsERR_NONE | Should successfully check for ARC capability |
  * |05|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_2, bool*| dsERR_NONE | Should successfully check for ARC capability |
  * |06|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_2, bool*| dsERR_NONE | Should successfully check for ARC capability |
@@ -1582,35 +1550,33 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
 
     gTestID = 31;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    dsError_t  result = dsERR_NONE;
+    bool PortResult1 = 0, PortResult2 = 0;
     uint8_t numInputPorts = 0;
-    bool isArcPort1  = false; 
-    bool isArcPort2  = false;
 
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Check if HDMI ARC is supported based on the number of input ports
-    if (numInputPorts > 0) {
-        // Step 3: Call dsIsHdmiARCPort() with valid input (dsHDMI_IN_PORT_0)
-        UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_0, &isArcPort1), dsERR_NONE);
+    // Step 2: Check if HDMI ARC is supported based on the device type
+    if (gSourceType == 0) {
 
-        // Step 4: Call dsIsHdmiARCPort() with valid input (dsHDMI_IN_PORT_1)
-        UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_1, &isArcPort2), dsERR_NONE);
+        // step 3 to 7: validating dsIsHdmiARCPort with valid Input and compare the Results
+        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+            result = dsIsHdmiARCPort(port, &PortResult1);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-        // Step 5: Call dsIsHdmiARCPort() with valid input (dsHDMI_IN_PORT_2)
-        UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_2, &isArcPort1), dsERR_NONE);
+            result = dsIsHdmiARCPort(port, &PortResult2);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-        // Step 6: Call dsIsHdmiARCPort() with valid input (dsHDMI_IN_PORT_2)
-        UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_2, &isArcPort2), dsERR_NONE);
+            UT_ASSERT_EQUAL(PortResult1, PortResult2);
+        }
 
-        // Step 7: Compare the values of steps 4 and 5 to make sure they equal one another
-        UT_ASSERT_EQUAL(isArcPort1, isArcPort2);
-    
-    } else {
+    } else if (gSourceType == 1) {
         // Step 8:Call dsIsHdmiARCPort() with valid input for source devices
-        UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_0, &isArcPort1), dsERR_OPERATION_NOT_SUPPORTED);
+        UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_0, &PortResult1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
     // Step 9: Call dsHdmiInTerm() to ensure deinitialization
@@ -1621,13 +1587,13 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
 
 /**
  * @brief Ensure dsIsHdmiARCPort() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 032@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1637,9 +1603,9 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
  * |04|Call dsIsHdmiARCPort() with invalid value |dsHDMI_IN_PORT_0, NULL| dsERR_INVALID_PARAM | Should Pass |
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |06|Call dsIsHdmiARCPort() after terminating the HDMI input sub-system | dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink(void) {
 
@@ -1667,79 +1633,62 @@ void test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink(void) {
     result = dsIsHdmiARCPort(dsHDMI_IN_PORT_0, &isArcPort);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetEDIDBytesInfo() correctly retrieves the EDID bytes information during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 033@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_0, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
- * |04|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_1, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
+ * |02|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_0, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
+ * |03|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_1, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
+ * |04|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_2, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
  * |05|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_2, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
- * |06|Call dsGetEDIDBytesInfo() with valid inputs |dsHDMI_IN_PORT_2, unsigned char*, int*| dsERR_NONE | Should return EDID bytes information successfully |
- * |07|Compare the results and make sure they are the same | | Success | The values should be the same |
- * |08|Call dsGetEDIDBytesInfo() with valid input |dsHDMI_IN_PORT_0, unsigned char*, int*| dsERR_OPERATION_NOT_SUPPORTED| For source devices
- * |09|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ * |06|Compare the results and make sure they are the same | | Success | The values should be the same |
+ * |07|Call dsGetEDIDBytesInfo() with valid input |dsHDMI_IN_PORT_0, unsigned char*, int*| dsERR_OPERATION_NOT_SUPPORTED| For source devices
+ * |08|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ *
  */
 void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
 
     gTestID = 33;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    unsigned char edidBytes1[255] = {0}, edidBytes2[255]={0};
+    int edidSize1 = 0, edidSize2 = 0;
     uint8_t numInputPorts = 0;
-    unsigned char* edidBytes1 = (unsigned char*) malloc(255);
-    unsigned char* edidBytes2 = (unsigned char*) malloc(255);
-    unsigned char* edidBytes3 = (unsigned char*) malloc(255);
-    unsigned char* edidBytes4 = (unsigned char*) malloc(255);
-    int edidSize1 = 0;
-    int edidSize2 = 0;
-    int edidSize3 = 0;
-    int edidSize4 = 0;
+
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0) {
-        // Step 3: Call dsGetEDIDBytesInfo() with valid input (dsHDMI_IN_PORT_0)
-        UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(dsHDMI_IN_PORT_0, edidBytes1, &edidSize1), dsERR_NONE);
+    if (gSourceType == 0) {
+        // Step 3 to Step 7
+        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+            UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(port, edidBytes1, &edidSize1), dsERR_NONE);
 
-        // Step 4: Call dsGetEDIDBytesInfo() with valid input (dsHDMI_IN_PORT_1)
-        UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(dsHDMI_IN_PORT_1, edidBytes2, &edidSize2), dsERR_NONE);
+            UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(port, edidBytes2, &edidSize2), dsERR_NONE);
 
-        // Step 5: Call dsGetEDIDBytesInfo() with valid input (dsHDMI_IN_PORT_2)
-        UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(dsHDMI_IN_PORT_2, edidBytes3, &edidSize3), dsERR_NONE);
-
-        // Step 6: Call dsGetEDIDBytesInfo() with valid input (dsHDMI_IN_PORT_2)
-        UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(dsHDMI_IN_PORT_2, edidBytes4, &edidSize4), dsERR_NONE);
-
-        // Step 7: Compare the results and make sure they are the same
-        UT_ASSERT_EQUAL(edidSize3, edidSize4);
-        UT_ASSERT_EQUAL(memcmp(edidBytes3, edidBytes4, edidSize3),0);
-    } else {
+            // Compare the results and make sure they are the same
+            UT_ASSERT_EQUAL(edidSize1, edidSize2);
+            UT_ASSERT_EQUAL(memcmp(edidBytes1, edidBytes2, edidSize1),0);
+        }
+    } else if (gSourceType == 1) {
         // Step 8: Call dsGetEDIDBytesInfo() with valid input for source devices
         UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(dsHDMI_IN_PORT_0, edidBytes1, &edidSize1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
     // Step 9: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
-
-    free(edidBytes1);
-    free(edidBytes2);
-    free(edidBytes3);
-    free(edidBytes4);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
 }
@@ -1771,7 +1720,7 @@ void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
 
     gTestID = 34;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    unsigned char* edidBytes = (unsigned char*) malloc(255);
+    unsigned char edidBytes[255] = {0};
     int edidSize = 0;
 
     // Step 1: Call dsGetEDIDBytesInfo() without initializing the HDMI input sub-system
@@ -1797,7 +1746,6 @@ void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
     result = dsGetEDIDBytesInfo(dsHDMI_IN_PORT_0, edidBytes, &edidSize);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    free(edidBytes);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
 }
@@ -1815,59 +1763,46 @@ void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_0, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
- * |04|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_1, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
+ * |02|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_0, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
+ * |03|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_1, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
+ * |04|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_2, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
  * |05|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_2, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
- * |06|Call dsGetHDMISPDInfo() with valid input |dsHDMI_IN_PORT_2, unsigned char*| dsERR_NONE | Should return HDMI SPD information successfully |
- * |07|Compare values from step 4/5 and make sure they're the same || Success | The values should be the same |
- * |08|Call dsGetHDMISPDInfo() with valid input | dsHDMI_IN_PORT_0, unsigned char* | dsERR_OPERATION_NOT_SUPPORTED | For source devices
- * |09|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |06|Compare values from step 4/5 and make sure they're the same || Success | The values should be the same |
+ * |07|Call dsGetHDMISPDInfo() with valid input | dsHDMI_IN_PORT_0, unsigned char* | dsERR_OPERATION_NOT_SUPPORTED | For source devices
+ * |08|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
 
     gTestID = 35;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    unsigned char spdInfo1[sizeof(struct dsSpd_infoframe_st)] = {0}, spdInfo2[sizeof(struct dsSpd_infoframe_st)] = {0};
     uint8_t numInputPorts = 0;
-    unsigned char* spdInfo1 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st));
-    unsigned char* spdInfo2 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st));
-    unsigned char* spdInfo3 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st));
-    unsigned char* spdInfo4 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st));
 
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0) {
-         // Step 3: Call dsGetHDMISPDInfo() with valid input (dsHDMI_IN_PORT_0)
-         UT_ASSERT_EQUAL(dsGetHDMISPDInfo(dsHDMI_IN_PORT_0, spdInfo1), dsERR_NONE);
+    if (gSourceType == 0) {
+        // Step 3 to Step 7
+        for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
 
-        // Step 4: Call dsGetHDMISPDInfo() with valid input (dsHDMI_IN_PORT_1)
-        UT_ASSERT_EQUAL(dsGetHDMISPDInfo(dsHDMI_IN_PORT_1, spdInfo2), dsERR_NONE);
+            // Step 3: Call dsGetHDMISPDInfo() with valid input (dsHDMI_IN_PORT_0)
+            UT_ASSERT_EQUAL(dsGetHDMISPDInfo(port, spdInfo1), dsERR_NONE);
 
-        // Step 5: Call dsGetHDMISPDInfo() with valid input (dsHDMI_IN_PORT_2)
-        UT_ASSERT_EQUAL(dsGetHDMISPDInfo(dsHDMI_IN_PORT_2, spdInfo3), dsERR_NONE);
+            // Step 4: Call dsGetHDMISPDInfo() with valid input (dsHDMI_IN_PORT_1)
+            UT_ASSERT_EQUAL(dsGetHDMISPDInfo(port, spdInfo2), dsERR_NONE);
 
-        // Step 6: Call dsGetHDMISPDInfo() with valid input (dsHDMI_IN_PORT_2)
-        UT_ASSERT_EQUAL(dsGetHDMISPDInfo(dsHDMI_IN_PORT_2, spdInfo4), dsERR_NONE);
-
-        // Step 7: Compare the results and make sure they are the same
-        UT_ASSERT_EQUAL(memcmp(spdInfo3, spdInfo4,sizeof(struct dsSpd_infoframe_st)),0);
-
-    } else {
-        // Step 8: Call dsGetHDMISPDInfo() with valid input for source devices 
+            // Step 7: Compare the results and make sure they are the same
+            UT_ASSERT_EQUAL(memcmp(spdInfo1, spdInfo2,sizeof(struct dsSpd_infoframe_st)),0);
+        }
+    } else if (gSourceType == 1) {
+        // Step 8: Call dsGetHDMISPDInfo() with valid input for source devices
         UT_ASSERT_EQUAL(dsGetHDMISPDInfo(dsHDMI_IN_PORT_0, spdInfo1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
     // Step 9: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
-
-    free(spdInfo1);
-    free(spdInfo2);
-    free(spdInfo3);
-    free(spdInfo4);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
 }
@@ -1898,11 +1833,12 @@ void test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink(void) {
 
     gTestID = 36;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    unsigned char* spdInfo1 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st)); 
+
+    unsigned char spdInfo1[sizeof(struct dsSpd_infoframe_st)] = {0};
 
     // Step 1: Call dsGetHDMISPDInfo() without initializing the HDMI input sub-system
     dsError_t result = dsGetHDMISPDInfo(dsHDMI_IN_PORT_0, spdInfo1);
-    CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_GENERAL); 
+    CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_GENERAL);
 
     // Step 2: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -1920,9 +1856,8 @@ void test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink(void) {
     result = dsGetHDMISPDInfo(dsHDMI_IN_PORT_0, spdInfo1);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_GENERAL);
 
-    free(spdInfo1);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
@@ -1938,50 +1873,36 @@ void test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsSetEdidVersion() with valid values |dsHDMI_IN_PORT_0, HDMI_EDID_VER_14| dsERR_NONE | Should set EDID version successfully |
- * |04|Call dsSetEdidVersion() with valid values |dsHDMI_IN_PORT_0, HDMI_EDID_VER_20| dsERR_NONE | Should set EDID version successfully |
- * |05|Call dsSetEdidVersion() with valid values |dsHDMI_IN_PORT_1, HDMI_EDID_VER_14| dsERR_NONE | Should set EDID version successfully |
- * |06|Call dsSetEdidVersion() with valid values |dsHDMI_IN_PORT_2, HDMI_EDID_VER_14| dsERR_NONE | Should set EDID version successfully |
- * |07|Call dsSetEdidVersion() with valid values | dsHDMI_IN_PORT_0, HDMI_EDID_VER_14 | dsERR_OPERATION_NOT_SUPPORTED | For source devices
- * |08|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsSetEdidVersion() with valid values for each port and each EDID version
+ * |03|Call dsSetEdidVersion() with valid values | dsHDMI_IN_PORT_0, HDMI_EDID_VER_14 | dsERR_OPERATION_NOT_SUPPORTED | For source devices
+ * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
 
     gTestID = 37;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint32_t ver14 = 0;
-    uint32_t ver20 = 0;
+    tv_hdmi_edid_version_t ver14 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersions/0");
+    tv_hdmi_edid_version_t ver20 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersions/1");
     uint8_t numInputPorts = 0;
 
-    ver14 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersions/0");
-
-    ver20 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersions/1");
-
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
-    
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0) {
-        // Step 3: Call dsSetEdidVersion() with valid values (dsHDMI_IN_PORT_0, HDMI_EDID_VER_14)
-        UT_ASSERT_EQUAL(dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14), dsERR_NONE);
-    
-        // Step 4: Call dsSetEdidVersion() with valid values (dsHDMI_IN_PORT_0, HDMI_EDID_VER_20)
-        UT_ASSERT_EQUAL(dsSetEdidVersion(dsHDMI_IN_PORT_0, ver20), dsERR_NONE);
 
-        // Step 5: Call dsSetEdidVersion() with valid values (dsHDMI_IN_PORT_1, HDMI_EDID_VER_14)
-        UT_ASSERT_EQUAL(dsSetEdidVersion(dsHDMI_IN_PORT_1, ver14), dsERR_NONE);
-
-        // Step 6: Call dsSetEdidVersion() with valid values (dsHDMI_IN_PORT_2, HDMI_EDID_VER_14)
-        UT_ASSERT_EQUAL(dsSetEdidVersion(dsHDMI_IN_PORT_2, ver14), dsERR_NONE);
-    } else {
-       // Step 7: Call dsSetEdidVersion() with valid values for source devices
+    if (gSourceType == 0) {
+	 
+	for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+              // Step 2: Call dsSetEdidVersion() with valid values for each port and each EDID version
+              UT_ASSERT_EQUAL(dsSetEdidVersion(port, ver14), dsERR_NONE);
+              UT_ASSERT_EQUAL(dsSetEdidVersion(port, ver20), dsERR_NONE);
+         }
+    } else if (gSourceType == 1) {
+       // Step 3: Call dsSetEdidVersion() with valid values for source devices
        UT_ASSERT_EQUAL(dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 8: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 4: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -2013,7 +1934,7 @@ void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
 
     gTestID = 38;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t ver14 = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/EdidVersions/0");
+    tv_hdmi_edid_version_t ver14 = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/EdidVersions/0");
 
     // Step 1: Call dsSetEdidVersion() without initializing the HDMI input sub-system
     dsError_t result = dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14);
@@ -2051,37 +1972,39 @@ void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsGetEdidVersion() with all valid ports and call the last one twice|[Valid Port], tv_hdmi_edid_version_t*| dsERR_NONE | Should Pass |
- * |04|Compare the values from final two calls in step 2 and make sure they match || Success | The values should be the same |
- * |05|Call dsGetEdidVersion() with valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
- * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsGetEdidVersion() with all valid ports and call the last one twice|[Valid Port], tv_hdmi_edid_version_t*| dsERR_NONE | Should Pass |
+ * |03|Compare the values from final two calls in step 2 and make sure they match || Success | The values should be the same |
+ * |04|Call dsGetEdidVersion() with valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
 
     gTestID = 39;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    dsError_t  result = dsERR_NONE;
+    tv_hdmi_edid_version_t edid_version_1 = HDMI_EDID_VER_MAX;
+    tv_hdmi_edid_version_t edid_version_2 = HDMI_EDID_VER_MAX;
     uint8_t numInputPorts = 0;
-    tv_hdmi_edid_version_t edid_version_1 = dsERR_NONE;
-    tv_hdmi_edid_version_t edid_version_2 = dsERR_NONE;
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0) {
+    if (gSourceType == 0) {
        // Step 3: Call dsGetEdidVersion() with valid values (dsHDMI_IN_PORT_0, tv_hdmi_edid_version_t*)
-       UT_ASSERT_EQUAL(dsGetEdidVersion(dsHDMI_IN_PORT_0, &edid_version_1), dsERR_NONE);
-       UT_ASSERT_EQUAL(dsGetEdidVersion(dsHDMI_IN_PORT_1, &edid_version_1), dsERR_NONE);
-       UT_ASSERT_EQUAL(dsGetEdidVersion(dsHDMI_IN_PORT_2, &edid_version_1), dsERR_NONE);
-       UT_ASSERT_EQUAL(dsGetEdidVersion(dsHDMI_IN_PORT_2, &edid_version_2), dsERR_NONE);
+       for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+            result = dsGetEdidVersion(port, &edid_version_1);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-       // Step 4: Compare the values from steps 4/5 and make sure they match
-       UT_ASSERT_EQUAL(edid_version_1, edid_version_2);
-    } else {
-       // Step 5: Call dsGetEdidVersion() with valid ports 
+            result = dsGetEdidVersion(port, &edid_version_2);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
+
+            UT_ASSERT_EQUAL(&edid_version_1, &edid_version_2);
+     
+      }
+    } else if (gSourceType == 1) {
+       // Step 5: Call dsGetEdidVersion() with valid ports
        UT_ASSERT_EQUAL(dsGetEdidVersion(dsHDMI_IN_PORT_0, &edid_version_1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
@@ -2109,7 +2032,7 @@ void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
  * |04|Call dsGetEdidVersion() with invalid inputs |dsHDMI_IN_PORT_0, NULL| dsERR_INVALID_PARAM | Should Pass |
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |06|Call dsGetEdidVersion() without initializing the HDMI input sub-system |dsHDMI_IN_PORT_0, tv_hdmi_edid_version_t*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
  *
  */
@@ -2117,7 +2040,7 @@ void test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink(void) {
 
     gTestID = 40;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    tv_hdmi_edid_version_t edid_version = dsERR_NONE;
+    tv_hdmi_edid_version_t edid_version = HDMI_EDID_VER_MAX;
 
     // Step 1: Call dsGetEdidVersion() without initializing the HDMI input sub-system
     dsError_t result = dsGetEdidVersion(dsHDMI_IN_PORT_0, &edid_version);
@@ -2155,51 +2078,42 @@ void test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsGetAllmStatus() with valid inputs |dsHDMI_IN_PORT_0, bool*| dsERR_NONE | Should retrieve ALLM status successfully |
- * |04|Call dsGetAllmStatus() with valid inputs |dsHDMI_IN_PORT_1, bool*| dsERR_NONE | Should retrieve ALLM status successfully |
- * |05|Call dsGetAllmStatus() with valid inputs |dsHDMI_IN_PORT_2, bool*| dsERR_NONE | Should retrieve ALLM status successfully |
- * |06|Call dsGetAllmStatus() with valid inputs |dsHDMI_IN_PORT_2, bool*| dsERR_NONE | Should retrieve ALLM status successfully |
- * |07|Compare the results of steps 4/5 and make sure they are the same || Success | The returned values should be the same |
- * |08|Call dsGetAllmStatus() with valid inputs | dsHDMI_IN_PORT_0, bool*| dsERR_OPERATION_NOT_SUPPORTED | For source devices
- * |09|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsGetAllmStatus() with valid inputs |dsHDMI_IN_PORT_0, bool*| dsERR_NONE | Should retrieve ALLM status successfully |
+ * |03|Call dsGetAllmStatus() with valid inputs | dsHDMI_IN_PORT_0, bool*| dsERR_OPERATION_NOT_SUPPORTED | For source devices
+ * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
 
     gTestID = 41;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    bool allm_status_1 = 0 , allm_status_2 = 0;
+    dsError_t  result = dsERR_NONE;
     uint8_t numInputPorts = 0;
-    bool allm_status_1 = false;
-    bool allm_status_2 = false;
-    bool allm_status_3 = false;
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0) {
-       // Step 2: Call dsGetAllmStatus() with valid inputs (dsHDMI_IN_PORT_0, bool*)
-       UT_ASSERT_EQUAL(dsGetAllmStatus(dsHDMI_IN_PORT_0, &allm_status_1), dsERR_NONE);
+    if (gSourceType == 0) {
 
-       // Step 3: Call dsGetAllmStatus() with valid inputs (dsHDMI_IN_PORT_1, bool*)
-       UT_ASSERT_EQUAL(dsGetAllmStatus(dsHDMI_IN_PORT_1, &allm_status_2), dsERR_NONE);
+	   // Step 2: Call dsGetAllmStatus() with valid inputs
+	   for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+           result = dsGetAllmStatus(port, &allm_status_1);
+           UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-       // Step 4: Call dsGetAllmStatus() with valid inputs (dsHDMI_IN_PORT_2, bool*)
-       UT_ASSERT_EQUAL(dsGetAllmStatus(dsHDMI_IN_PORT_2, &allm_status_3), dsERR_NONE);
+            result = dsGetAllmStatus(port, &allm_status_2);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-       // Step 5: Call dsGetAllmStatus() with valid inputs (dsHDMI_IN_PORT_2, bool*)
-       UT_ASSERT_EQUAL(dsGetAllmStatus(dsHDMI_IN_PORT_2, &allm_status_1), dsERR_NONE);
+            UT_ASSERT_EQUAL(allm_status_1, allm_status_2);
+        }
 
-       // Step 6: Compare the results of steps 4/5 and make sure they are the same
-       UT_ASSERT_EQUAL(allm_status_1, allm_status_3);
-    } else {
-       // Step 7: Call dsGetAllmStatus() with valid inputs
+    } else if (gSourceType == 1) {
+       // Step 3: Call dsGetAllmStatus() with valid inputs
        UT_ASSERT_EQUAL(dsGetAllmStatus(dsHDMI_IN_PORT_0, &allm_status_1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 8: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 4: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -2269,39 +2183,35 @@ void test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsGetSupportedGameFeaturesList() with valid inputs |dsSupportedGameFeatureList_t*| dsERR_NONE | Should retrieve list successfully |
- * |04|Call dsGetSupportedGameFeaturesList() with valid inputs and Comparing the results to the expected values defined in the test profile |
- * |05||Call dsGetSupportedGameFeaturesList() with valid inputs | dsERR_OPERATION_NOT_SUPPORTED |For source devices
- * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsGetSupportedGameFeaturesList() with valid inputs |dsSupportedGameFeatureList_t*| dsERR_NONE | Should retrieve list successfully |
+ * |03|Call dsGetSupportedGameFeaturesList() with valid inputs and Comparing the results to the expected values defined in the test profile |
+ * |04||Call dsGetSupportedGameFeaturesList() with valid inputs | dsERR_OPERATION_NOT_SUPPORTED |For source devices
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsGetSupportedGameFeaturesList_sink(void) {
 
     gTestID = 43;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t numInputPorts = 0;
     dsSupportedGameFeatureList_t supported_features_1 = {0};
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0) {
-       // Step 3: Call dsGetSupportedGameFeaturesList() with valid inputs (dsSupportedGameFeatureList_t*)
+    if (gSourceType == 0) {
+       // Step 2: Call dsGetSupportedGameFeaturesList() with valid inputs (dsSupportedGameFeatureList_t*)
        UT_ASSERT_EQUAL(dsGetSupportedGameFeaturesList(&supported_features_1), dsERR_NONE);
 
-       //step 4:Validating the results retrieved from dsGetSupportedGameFeaturesList() 
+       //step 3:Validating the results retrieved from dsGetSupportedGameFeaturesList()
        //and Comparing the results to the expected values defined in the profile file
        UT_ASSERT_KVP_EQUAL_PROFILE_STRING(supported_features_1.gameFeatureList, "dsHdmiIn/gameFeatures/feature");
        UT_ASSERT_KVP_EQUAL_PROFILE_UINT32(supported_features_1.gameFeatureCount, "dsHdmiIn/gameFeatures/count");
-    } else {
-       // Step 5:Call dsGetSupportedGameFeaturesList() with valid inputs	    
+    } else if (gSourceType == 1) {
+       // Step 4:Call dsGetSupportedGameFeaturesList() with valid inputs
        UT_ASSERT_EQUAL(dsGetSupportedGameFeaturesList(&supported_features_1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -2367,11 +2277,10 @@ void test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool: false| dsERR_NONE | Port 0 should be selected |
- * |04|Call dsGetAVLatency() with valid input |int*, int*| dsERR_NONE | Should retrieve AV latency values successfully |
- * |05|Call dsGetAVLatency() with valid input | dsERR_OPERATION_NOT_SUPPORTED | For source devices
- * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
+ * |02|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool: false| dsERR_NONE | Port 0 should be selected |
+ * |03|Call dsGetAVLatency() with valid input |int*, int*| dsERR_NONE | Should retrieve AV latency values successfully |
+ * |04|Call dsGetAVLatency() with valid input | dsERR_OPERATION_NOT_SUPPORTED | For source devices
+ * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsGetAVLatency_sink(void) {
@@ -2380,25 +2289,23 @@ void test_l1_dsHdmiIn_positive_dsGetAVLatency_sink(void) {
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     int audioLatency1 =0;
     int videoLatency1 =0;
-    uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0){
-        // Step 3: Call dsHdmiInSelectPort() to select Port 0
+
+    if (gSourceType == 0) {
+        // Step 2: Call dsHdmiInSelectPort() to select Port 0
         UT_ASSERT_EQUAL(dsHdmiInSelectPort(dsHDMI_IN_PORT_0, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
 
-        // Step 4: Call dsGetAVLatency() with valid inputs (int*, int*)
+        // Step 3: Call dsGetAVLatency() with valid inputs (int*, int*)
         UT_ASSERT_EQUAL(dsGetAVLatency(&audioLatency1, &videoLatency1), dsERR_NONE);
-    } else {
-        //Step 5: Call dsGetAVLatency() with valid inputs
+    } else if (gSourceType == 1) {
+        //Step 4: Call dsGetAVLatency() with valid inputs
 	UT_ASSERT_EQUAL(dsGetAVLatency(&audioLatency1, &videoLatency1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 6: Call dsHdmiInTerm() to ensure deinitialization
+    // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -2430,7 +2337,7 @@ void test_l1_dsHdmiIn_negative_dsGetAVLatency_sink(void) {
 
     gTestID = 46;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    int audioLatency =0; 
+    int audioLatency =0;
     int	videoLatency =0;
 
     // Step 1: Call dsGetAVLatency() without initializing the HDMI input sub-system
@@ -2469,38 +2376,35 @@ void test_l1_dsHdmiIn_negative_dsGetAVLatency_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize HDMI input using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsSetEdid2AllmSupport() with all valid ports and enable EDID ALLM support | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: true | dsERR_NONE | Should Pass |
- * |04|Call dsSetEdid2AllmSupport() to disable EDID ALLM support | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: false | dsERR_NONE | Should Pass |
- * |05|Call dsSetEdid2AllmSupport() with valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
- * |06|Terminate the HDMI input using dsHdmiInTerm() | | dsERR_NONE | Clean up after test |
+ * |02|Call dsSetEdid2AllmSupport() with all valid ports and enable EDID ALLM support | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: true | dsERR_NONE | Should Pass |
+ * |03|Call dsSetEdid2AllmSupport() to disable EDID ALLM support | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: false | dsERR_NONE | Should Pass |
+ * |04|Call dsSetEdid2AllmSupport() with valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
+ * |05|Terminate the HDMI input using dsHdmiInTerm() | | dsERR_NONE | Clean up after test |
  *
  */
 void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
 
     gTestID = 47;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint8_t numInputPorts = 0;
+
 
     // Step 1: Initialize HDMI input using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0) {
-        // Step 3: Call dsSetEdid2AllmSupport() with all valid ports and enable EDID ALLM support
+    if (gSourceType == 0) {
+        // Step 2: Call dsSetEdid2AllmSupport() with all valid ports and enable EDID ALLM support
         UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, true), dsERR_NONE);
         UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_1, true), dsERR_NONE);
         UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_2, true), dsERR_NONE);
-    
-        // Step 4: Call dsSetEdid2AllmSupport() to disable EDID ALLM support
+
+        // Step 3: Call dsSetEdid2AllmSupport() to disable EDID ALLM support
         UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, false), dsERR_NONE);
-    } else {
-        // Step 5:Call dsSetEdid2AllmSupport() with valid ports
+    } else if (gSourceType == 1) {
+        // Step 4:Call dsSetEdid2AllmSupport() with valid ports
         UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, true), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 6: Terminate the HDMI input using dsHdmiInTerm()
+    // Step 5: Terminate the HDMI input using dsHdmiInTerm()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -2525,7 +2429,7 @@ void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
  * |05|Call dsSetEdid2AllmSupport() after termination | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: true | dsERR_NOT_INITIALIZED | Should Pass |
  *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported or has failed respectively.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink(void) {
 
@@ -2565,11 +2469,10 @@ void test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink(void) {
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize HDMI input using dsHdmiInInit() | | dsERR_NONE | Should Pass |
- * |02|Get the number of input ports from the profile file
- * |03|Call dsGetEdid2AllmSupport() with all valid ports, and call the last port twice to verify EDID ALLM support | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: bool* | dsERR_NONE | Should Pass |
- * |04|Compare the returned values from steps 2/3 and verify that they are the same |  | success | The values should be the same |
- * |05|Call dsGetEdid2AllmSupport() with  valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
- * |06|Terminate the HDMI input using dsHdmiInTerm() | | dsERR_NONE | Clean up after test |
+ * |02|Call dsGetEdid2AllmSupport() with all valid ports, and call the last port twice to verify EDID ALLM support | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: bool* | dsERR_NONE | Should Pass |
+ * |03|Compare the returned values from steps 2/3 and verify that they are the same |  | success | The values should be the same |
+ * |04|Call dsGetEdid2AllmSupport() with  valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
+ * |05|Terminate the HDMI input using dsHdmiInTerm() | | dsERR_NONE | Clean up after test |
  *
  * @note Ensure that the device supports querying of the EDID ALLM feature before running this test.
  *
@@ -2578,30 +2481,36 @@ void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
 
     gTestID = 49;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    bool allmSupport1 = false; 
-    bool allmSupport2 = false;
+    bool allmSupport1 = 0;
+    bool allmSupport2 = 0;
+    dsError_t  result = dsERR_NONE;
     uint8_t numInputPorts = 0;
+
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize HDMI input using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Get the number of input ports from the profile file
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
-    if (numInputPorts > 0) {
-        // Step 3: Call dsGetEdid2AllmSupport() to verify EDID ALLM support
-        UT_ASSERT_EQUAL(dsGetEdid2AllmSupport(dsHDMI_IN_PORT_0, &allmSupport1), dsERR_NONE);
-        UT_ASSERT_EQUAL(dsGetEdid2AllmSupport(dsHDMI_IN_PORT_1, &allmSupport1), dsERR_NONE);
-        UT_ASSERT_EQUAL(dsGetEdid2AllmSupport(dsHDMI_IN_PORT_2, &allmSupport1), dsERR_NONE);
-        UT_ASSERT_EQUAL(dsGetEdid2AllmSupport(dsHDMI_IN_PORT_2, &allmSupport2), dsERR_NONE);
 
-        // Step 4: Compare the returned values from steps 2/3 and verify that they are the same
-        UT_ASSERT_EQUAL(allmSupport1, allmSupport2);
-    } else {
-      // Step 5:Call dsGetEdid2AllmSupport() with valid ports
+    if (gSourceType == 0) {
+
+        // Step 2 to 3: Call dsGetEdid2AllmSupport() to verify EDID ALLM support
+	for (int port = dsHDMI_IN_PORT_0; port < numInputPorts; port++) {
+            result = dsGetEdid2AllmSupport(port, &allmSupport1);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
+
+            result = dsGetEdid2AllmSupport(port, &allmSupport2);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
+
+            UT_ASSERT_EQUAL(allmSupport1, allmSupport2);
+        }
+
+    } else if (gSourceType == 1) {
+      // Step 4:Call dsGetEdid2AllmSupport() with valid ports
       UT_ASSERT_EQUAL(dsGetEdid2AllmSupport(dsHDMI_IN_PORT_0, &allmSupport1), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
-    // Step 6: Terminate the HDMI input using dsHdmiInTerm()
+    // Step 5: Terminate the HDMI input using dsHdmiInTerm()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
     UT_LOG("\n Out %s\n", __FUNCTION__);
@@ -2635,7 +2544,7 @@ void test_l1_dsHdmiIn_negative_dsGetEdid2AllmSupport_sink(void) {
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     bool allmSupport = false;
 
-    // Step 1: Call dsGetEdid2AllmSupport() without initializing the HDMI input sub-system 
+    // Step 1: Call dsGetEdid2AllmSupport() without initializing the HDMI input sub-system
     dsError_t result = dsGetEdid2AllmSupport(dsHDMI_IN_PORT_0, &allmSupport);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_OPERATION_NOT_SUPPORTED);
 
@@ -2655,7 +2564,7 @@ void test_l1_dsHdmiIn_negative_dsGetEdid2AllmSupport_sink(void) {
     result = dsGetEdid2AllmSupport(dsHDMI_IN_PORT_0, &allmSupport);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_OPERATION_NOT_SUPPORTED);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 static UT_test_suite_t * pSuite = NULL;
@@ -2668,10 +2577,9 @@ static UT_test_suite_t * pSuite2 = NULL;
  */
 int test_l1_dsHdmiIn_register ( void )
 {
-    ut_kvp_status_t status;
-    int32_t source_type = 0;
+    ut_kvp_status_t status = UT_KVP_STATUS_SUCCESS;
     pSuite2 = UT_add_suite( "[L1 dsHdmiIn --  advanced]", NULL, NULL );
- 
+
     status = ut_kvp_getStringField(ut_kvp_profile_getInstance(), "dsHdmiIn.Type", gDeviceType, TEST_DS_DEVICE_TYPE_SIZE);
 
     if (status == UT_KVP_STATUS_SUCCESS ) {
@@ -2682,7 +2590,8 @@ int test_l1_dsHdmiIn_register ( void )
             {
                 return -1;
             }
-            source_type = 1;
+
+            gSourceType = 1;
     }
     else if(!strncmp(gDeviceType, TEST_TYPE_SINK_VALUE, TEST_DS_DEVICE_TYPE_SIZE)) {
             // Create the test suite for sink type
@@ -2691,7 +2600,8 @@ int test_l1_dsHdmiIn_register ( void )
             {
                 return -1;
             }
-            source_type = 0;
+
+            gSourceType = 0;
          }
          else {
               UT_LOG_ERROR("Invalid platform type: %s", gDeviceType);
@@ -2732,39 +2642,36 @@ int test_l1_dsHdmiIn_register ( void )
     UT_add_test( pSuite, "dsHdmiInRegisterAviContentTypeChangeCB_L1_negative" ,test_l1_dsHdmiIn_negative_dsHdmiInRegisterAviContentTypeChangeCB );
     UT_add_test( pSuite2, "dsHdmiInGetStatus_L1_negative" ,test_l1_dsHdmiIn_negative_dsHdmiInGetStatus );
 
-   if ( source_type == 1 ){
-        UT_add_test( pSuite, "dsHdmiInSelectZoomMode_L1_positive" ,test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source );
-        UT_add_test( pSuite, "dsHdmiInSelectZoomMode_L1_negative" ,test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source );
-   }
 
-   if ( source_type == 0 ){
-	UT_add_test( pSuite, "dsIsHdmiARCPort_L1_positive" ,test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink );
-	UT_add_test( pSuite, "dsGetEDIDBytesInfo_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink );
-        UT_add_test( pSuite, "dsGetHDMISPDInfo_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink );
-        UT_add_test( pSuite, "dsSetEdidVersion_L1_positive" ,test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink );
-        UT_add_test( pSuite, "dsGetEdidVersion_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink );
-        UT_add_test( pSuite, "dsGetAllmStatus_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink );
-        UT_add_test( pSuite, "dsGetSupportedGameFeaturesList_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetSupportedGameFeaturesList_sink );
-        UT_add_test( pSuite, "dsGetAVLatency_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetAVLatency_sink );
-        UT_add_test( pSuite, "dsSetEdid2AllmSupport_l1_positive" ,test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink );
+    UT_add_test( pSuite, "dsHdmiInSelectZoomMode_L1_positive" ,test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source );
+    UT_add_test( pSuite, "dsHdmiInSelectZoomMode_L1_negative" ,test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source );
 
-        UT_add_test( pSuite, "dsGetEDIDBytesInfo_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink );
-        UT_add_test( pSuite, "dsGetHDMISPDInfo_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink );
-        UT_add_test( pSuite, "dsSetEdidVersion_L1_negative" ,test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink );
-        UT_add_test( pSuite, "dsGetEdidVersion_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink );
-        UT_add_test( pSuite, "dsGetAllmStatus_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink );
-        UT_add_test( pSuite, "dsGetSupportedGameFeaturesList_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink );
-        UT_add_test( pSuite, "dsGetAVLatency_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetAVLatency_sink );
-        UT_add_test( pSuite, "dsSetEdid2AllmSupport_l1_negative" ,test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink );
-        UT_add_test( pSuite2, "dsGetEdid2AllmSupport_l1_positive" ,test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink );
-        UT_add_test( pSuite2, "dsGetEdid2AllmSupport_l1_negative" ,test_l1_dsHdmiIn_negative_dsGetEdid2AllmSupport_sink );
-        UT_add_test( pSuite2, "dsIsHdmiARCPort_L1_negative" ,test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink );
-   }
+    UT_add_test( pSuite, "dsIsHdmiARCPort_L1_positive" ,test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink );
+    UT_add_test( pSuite, "dsGetEDIDBytesInfo_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink );
+    UT_add_test( pSuite, "dsGetHDMISPDInfo_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink );
+    UT_add_test( pSuite, "dsSetEdidVersion_L1_positive" ,test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink );
+    UT_add_test( pSuite, "dsGetEdidVersion_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink );
+    UT_add_test( pSuite, "dsGetAllmStatus_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink );
+    UT_add_test( pSuite, "dsGetSupportedGameFeaturesList_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetSupportedGameFeaturesList_sink );
+    UT_add_test( pSuite, "dsGetAVLatency_L1_positive" ,test_l1_dsHdmiIn_positive_dsGetAVLatency_sink );
+    UT_add_test( pSuite, "dsSetEdid2AllmSupport_l1_positive" ,test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink );
+    UT_add_test( pSuite, "dsGetEDIDBytesInfo_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink );
+    UT_add_test( pSuite, "dsGetHDMISPDInfo_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink );
+    UT_add_test( pSuite, "dsSetEdidVersion_L1_negative" ,test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink );
+    UT_add_test( pSuite, "dsGetEdidVersion_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink );
+    UT_add_test( pSuite, "dsGetAllmStatus_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink );
+    UT_add_test( pSuite, "dsGetSupportedGameFeaturesList_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink );
+    UT_add_test( pSuite, "dsGetAVLatency_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetAVLatency_sink );
+    UT_add_test( pSuite, "dsSetEdid2AllmSupport_l1_negative" ,test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink );
+    UT_add_test( pSuite2, "dsGetEdid2AllmSupport_l1_positive" ,test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink );
+    UT_add_test( pSuite2, "dsGetEdid2AllmSupport_l1_negative" ,test_l1_dsHdmiIn_negative_dsGetEdid2AllmSupport_sink );
+    UT_add_test( pSuite2, "dsIsHdmiARCPort_L1_negative" ,test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink );
+
 
    extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "dsHdmiIn/features/extendedEnumsSupported" );
 
    return 0;
-} 
+}
 
 /** @} */ // End of DS_HDMIIn_HALTEST_L1
 /** @} */ // End of DS_HDMIIn_HALTEST

--- a/src/test_l1_dsHdmiIn.c
+++ b/src/test_l1_dsHdmiIn.c
@@ -367,7 +367,8 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
 
     gTestID = 7;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    dsHdmiInStatus_t status1={0} , status2 = {0};
+    dsHdmiInStatus_t status1={0};
+    dsHdmiInStatus_t status2={0};
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()

--- a/src/test_l1_dsHdmiIn.c
+++ b/src/test_l1_dsHdmiIn.c
@@ -278,13 +278,13 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetNumberOfInputs(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     if (numInputPorts > 0) {
         // Step 2: Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports
         UT_ASSERT_EQUAL(dsHdmiInGetNumberOfInputs(&numInputs), dsERR_NONE);
 
         // Step 3: Verify that the number of HDMI input ports obtained matches the expected value from the profile
-        UT_ASSERT_KVP_EQUAL_PROFILE_UINT8(numInputs, "dsHdmiIn/HdmiInputPort/numberOfPorts");
+        UT_ASSERT_KVP_EQUAL_PROFILE_UINT8(numInputs, "dsHdmiIn/numberOfPorts");
     } else {
        // Step 4: For source devices without HDMI input support
        UT_ASSERT_EQUAL(dsHdmiInGetNumberOfInputs(&numInputs), 0);
@@ -374,7 +374,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     if (numInputPorts > 0) {
         // Step 2: Call dsHdmiInGetStatus()
         UT_ASSERT_EQUAL(dsHdmiInGetStatus(&status1), dsERR_NONE);
@@ -478,7 +478,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     if (numInputPorts > 0) {
         // Step 2 to Step 4: Call dsHdmiInSelectPort() with valid inputs
         for (uint8_t i = dsHDMI_IN_PORT_0; i < numInputPorts; i++)
@@ -583,7 +583,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInScaleVideo(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     if (numInputPorts > 0) {
         // Step 2: Scale HDMI input video (x=0, y=0, width=800, height=600)
         UT_ASSERT_EQUAL(dsHdmiInScaleVideo(0, 0, 800, 600), dsERR_NONE);
@@ -702,7 +702,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     if (numInputPorts > 0) {
         // Step 2: Call dsHdmiInSelectPort() to select Port 0
         UT_ASSERT_EQUAL(dsHdmiInSelectPort(dsHDMI_IN_PORT_0, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
@@ -802,7 +802,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     if (numInputPorts > 0) {
     	// Step 2: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
         UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(&resolution1), dsERR_NONE);
@@ -908,7 +908,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterConnectCB(void) {
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     // Step 2: Call dsHdmiInRegisterConnectCB() based on the number of input ports
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     if (numInputPorts > 0) {
          // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterConnectCB(mockConnectCallback), dsERR_NONE);
@@ -1542,7 +1542,7 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
     bool PortResult1 = 0, PortResult2 = 0;
     uint8_t numInputPorts = 0;
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -1648,7 +1648,7 @@ void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
     int edidSize1 = 0, edidSize2 = 0;
     uint8_t numInputPorts = 0;
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -1757,7 +1757,7 @@ void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
     unsigned char spdInfo1[sizeof(struct dsSpd_infoframe_st)] = {0}, spdInfo2[sizeof(struct dsSpd_infoframe_st)] = {0};
     uint8_t numInputPorts = 0;
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
@@ -1857,11 +1857,11 @@ void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
 
     gTestID = 37;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    tv_hdmi_edid_version_t ver14 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersions/0");
-    tv_hdmi_edid_version_t ver20 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersions/1");
+    tv_hdmi_edid_version_t ver14 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersion/0");
+    tv_hdmi_edid_version_t ver20 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersion/1");
     uint8_t numInputPorts = 0;
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
@@ -1908,7 +1908,7 @@ void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
 
     gTestID = 38;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    tv_hdmi_edid_version_t ver14 = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/EdidVersions/0");
+    tv_hdmi_edid_version_t ver14 = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/EdidVersion/0");
 
     // Step 1: Call dsSetEdidVersion() without initializing the HDMI input sub-system
     dsError_t result = dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14);
@@ -1960,7 +1960,7 @@ void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
     tv_hdmi_edid_version_t edid_version_1 = HDMI_EDID_VER_MAX;
     tv_hdmi_edid_version_t edid_version_2 = HDMI_EDID_VER_MAX;
     uint8_t numInputPorts = 0;
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -2064,7 +2064,7 @@ void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
     bool allm_status_1 = 0 , allm_status_2 = 0;
     dsError_t  result = dsERR_NONE;
     uint8_t numInputPorts = 0;
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -2361,7 +2361,7 @@ void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
 
     dsError_t  result = dsERR_NONE;
     uint8_t numInputPorts = 0;
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
 
     // Step 1: Initialize HDMI input using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -2464,7 +2464,7 @@ void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
     dsError_t  result = dsERR_NONE;
     uint8_t numInputPorts = 0;
 
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
+    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/numberOfPorts");
 
     // Step 1: Initialize HDMI input using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);

--- a/src/test_l1_dsHdmiIn.c
+++ b/src/test_l1_dsHdmiIn.c
@@ -114,8 +114,10 @@ static bool extendedEnumsSupported=false; //Default to not supported
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInInit(void) {
+
     gTestID = 1;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
@@ -150,8 +152,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInInit(void) {
  * @note Testing for the `dsERR_GENERAL` and `dsERR_RESOURCE_NOT_AVAILABLE` might be challenging since it requires a specific scenario where the attempted operation is not supported.
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInInit(void) {
+
     gTestID = 2;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
@@ -184,8 +188,10 @@ void test_l1_dsHdmiIn_negative_dsHdmiInInit(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInTerm(void) {
+
     gTestID = 3;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
@@ -222,8 +228,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInTerm(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInTerm(void) {
+
     gTestID = 4;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Call dsHdmiInTerm() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInTerm();
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -262,23 +270,23 @@ void test_l1_dsHdmiIn_negative_dsHdmiInTerm(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetNumberOfInputs(void) {
+
     gTestID = 5;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputs;
     uint8_t numInputPorts = 0;
-    
+
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
     // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
+        // Step 3: Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports
+        UT_ASSERT_EQUAL(dsHdmiInGetNumberOfInputs(&numInputs), dsERR_NONE);
 
-       // Step 3: Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports
-       UT_ASSERT_EQUAL(dsHdmiInGetNumberOfInputs(&numInputs), dsERR_NONE);
-
-       // Step 4: Verify that the number of HDMI input ports obtained matches the expected value from the profile
-       UT_ASSERT_KVP_EQUAL_PROFILE_UINT8(numInputs, "dsHdmiIn/HdmiInputPort/numberOfPorts");
+        // Step 4: Verify that the number of HDMI input ports obtained matches the expected value from the profile
+        UT_ASSERT_KVP_EQUAL_PROFILE_UINT8(numInputs, "dsHdmiIn/HdmiInputPort/numberOfPorts");
     } else {
        // Step 5: For source devices without HDMI input support
        UT_ASSERT_EQUAL(dsHdmiInGetNumberOfInputs(&numInputs), 0);
@@ -312,6 +320,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetNumberOfInputs(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInGetNumberOfInputs(void) {
+
     gTestID = 6;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputs;
@@ -358,6 +367,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetNumberOfInputs(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
+
     gTestID = 7;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     dsHdmiInStatus_t status1, status2;
@@ -417,6 +427,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInGetStatus(void) {
+
     gTestID = 8;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     dsHdmiInStatus_t status;
@@ -463,6 +474,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetStatus(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
+
     gTestID = 9;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputPorts = 0;
@@ -473,7 +485,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
     // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-       
+
         for (uint8_t i = dsHDMI_IN_PORT_0; i < numInputPorts; i++)
         {
              // Step 3: Call dsHdmiInSelectPort() to select Port 0
@@ -481,7 +493,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
 
              // Step 4: Call dsHdmiInSelectPort() to select Port 1
              UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, true, dsVideoPlane_SECONDARY, true), dsERR_NONE);
-      
+
              // Step 5: Call dsHdmiInSelectPort() to select Port 2
              UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
        }
@@ -490,7 +502,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
 	for (uint8_t i =  numInputPorts; i < dsHDMI_IN_PORT_MAX; i++)
         {
              // Step 6: Call dsHdmiInSelectPort() 
-	     UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_OPERATION_NOT_SUPPORTED);
+    	     UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_OPERATION_NOT_SUPPORTED);
         }
     }
      
@@ -524,6 +536,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
+
     gTestID = 10;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputPorts = 0;
@@ -578,6 +591,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInScaleVideo(void) {
+
     gTestID = 11;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputPorts = 0;
@@ -635,8 +649,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInScaleVideo(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInScaleVideo(void) {
+
     gTestID = 12;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Call dsHdmiInScaleVideo() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInScaleVideo(0, 0, 800, 600);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -696,10 +712,11 @@ void test_l1_dsHdmiIn_negative_dsHdmiInScaleVideo(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
+
     gTestID = 13;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputPorts = 0;
-    
+
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
@@ -718,7 +735,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
        // Step 5:Calling dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_MAX)
        UT_ASSERT_EQUAL(dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_MAX), dsERR_OPERATION_NOT_SUPPORTED);
     }
-    
+
     // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -748,21 +765,23 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source(void) {
+
     gTestID = 14;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Call dsHdmiInSelectZoomMode() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_NONE);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
     // Step 2: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
-    
+
     // Step 3: Call dsHdmiInSelectPort() to select Port 0
     UT_ASSERT_EQUAL(dsHdmiInSelectPort(dsHDMI_IN_PORT_0, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
 
     // Step 4: Call dsHdmiInSelectZoomMode() with invalid value (dsVIDEO_ZOOM_MAX)
     UT_ASSERT_EQUAL(dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_MAX),dsERR_INVALID_PARAM);
-    
+
     // Step 5: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -795,6 +814,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
+
     gTestID = 15;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     dsVideoPortResolution_t resolution1;
@@ -807,7 +827,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
     // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-	// Step 3: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
+    	// Step 3: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
         UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(&resolution1), dsERR_NONE);
         UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(&resolution2), dsERR_NONE);
 
@@ -826,7 +846,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
       // Step 6: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
       UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(&resolution1), dsERR_OPERATION_NOT_SUPPORTED);
     }
-    
+
     // Step 7: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -855,8 +875,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInGetCurrentVideoMode(void) {
+
     gTestID = 16;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Call dsHdmiInGetCurrentVideoMode() without initializing the HDMI input sub-system
     dsVideoPortResolution_t resolution;
     dsError_t result = dsHdmiInGetCurrentVideoMode(&resolution);
@@ -900,22 +922,23 @@ void mockConnectCallback(dsHdmiInPort_t Port, bool isPortConnected){
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterConnectCB(void) {
+
     gTestID = 17;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputPorts = 0;
-    
+
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
-    
+
     // Step 2: Call dsHdmiInRegisterConnectCB() based on the number of input ports
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
-	 // For sink devices
+    	 // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterConnectCB(mockConnectCallback), dsERR_NONE);
-     } else {
-	 // For source devices
-	 UT_ASSERT_EQUAL(dsHdmiInRegisterConnectCB(mockConnectCallback), dsERR_OPERATION_NOT_SUPPORTED);
-     }
+    } else {
+    	// For source devices
+    	UT_ASSERT_EQUAL(dsHdmiInRegisterConnectCB(mockConnectCallback), dsERR_OPERATION_NOT_SUPPORTED);
+    }
 
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
@@ -945,8 +968,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterConnectCB(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterConnectCB(void) {
+
     gTestID = 18;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Call dsHdmiInRegisterConnectCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterConnectCB(mockConnectCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -989,6 +1014,7 @@ void mockSignalCallback(dsHdmiInPort_t port, dsHdmiInSignalStatus_t sigStatus){
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterSignalChangeCB(void) {
+
     gTestID = 19;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputPorts = 0;
@@ -1000,11 +1026,11 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterSignalChangeCB(void) {
 
     // Step 2: Call dsHdmiInRegisterSignalChangeCB() based on the number of input ports
     if (numInputPorts > 0) {
-	// For sink devices
-	UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_NONE);
+    	// For sink devices
+    	UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_NONE);
 
     } else {
-	// For source devices  
+    	// For source devices  
         UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
@@ -1036,8 +1062,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterSignalChangeCB(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterSignalChangeCB(void) {
+
     gTestID = 20;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Call dsHdmiInRegisterSignalChangeCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterSignalChangeCB(mockSignalCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -1080,6 +1108,7 @@ void mockStatusChangeCallback(dsHdmiInStatus_t inputStatus){
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterStatusChangeCB(void) {
+
     gTestID = 21;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputPorts = 0;
@@ -1089,15 +1118,15 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterStatusChangeCB(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterStatusChangeCB()
+    // Step 2: Call dsHdmiInRegisterStatusChangeCB() based on the number of input ports
     if (numInputPorts > 0) {
-	// For sink devices
+    	// For sink devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterStatusChangeCB(mockStatusChangeCallback), dsERR_NONE);
     } else {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterStatusChangeCB(mockStatusChangeCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
-    
+
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -1126,8 +1155,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterStatusChangeCB(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterStatusChangeCB(void) {
+
     gTestID = 22;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     // Step 1: Call dsHdmiInRegisterStatusChangeCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterStatusChangeCB(mockStatusChangeCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -1170,16 +1201,17 @@ void mockVideoModeUpdateCallback(dsHdmiInPort_t port, dsVideoPortResolution_t vi
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterVideoModeUpdateCB(void) {
+
     gTestID = 23;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
     uint8_t numInputPorts = 0;
-   
+
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterVideoModeUpdateCB()
+    // Step 2: Call dsHdmiInRegisterVideoModeUpdateCB() based on the number of input ports
     if (numInputPorts > 0) {
         // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterVideoModeUpdateCB(mockVideoModeUpdateCallback), dsERR_NONE);
@@ -1188,7 +1220,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterVideoModeUpdateCB(void) {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterVideoModeUpdateCB(mockVideoModeUpdateCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
-    
+
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -1217,8 +1249,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterVideoModeUpdateCB(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterVideoModeUpdateCB(void) {
+
     gTestID = 24;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+
     // Step 1: Call dsHdmiInRegisterVideoModeUpdateCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterVideoModeUpdateCB(mockVideoModeUpdateCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -1261,6 +1295,7 @@ void mockALLMChangeCallback(dsHdmiInPort_t port, bool allm_mode){
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAllmChangeCB(void) {
+
     gTestID = 25;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -1270,7 +1305,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAllmChangeCB(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterAllmChangeCB()
+    // Step 2: Call dsHdmiInRegisterAllmChangeCB() based on the number of input ports
     if (numInputPorts > 0) {
         // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterAllmChangeCB(mockALLMChangeCallback), dsERR_NONE);
@@ -1279,7 +1314,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAllmChangeCB(void) {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterAllmChangeCB(mockALLMChangeCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
-    
+
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -1308,8 +1343,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAllmChangeCB(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAllmChangeCB(void) {
+
     gTestID = 26;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     // Step 1: Call dsHdmiInRegisterAllmChangeCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterAllmChangeCB(mockALLMChangeCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -1352,6 +1389,7 @@ void mockLatencyChangeCallback(int audio_latency, int video_latency){
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAVLatencyChangeCB(void) {
+
     gTestID = 27;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -1361,7 +1399,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAVLatencyChangeCB(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterAVLatencyChangeCB()
+    // Step 2: Call dsHdmiInRegisterAVLatencyChangeCB() based on the number of input ports
     if (numInputPorts > 0) {
         // For sink devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterAVLatencyChangeCB(mockLatencyChangeCallback), dsERR_NONE);
@@ -1370,7 +1408,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAVLatencyChangeCB(void) {
         // For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterAVLatencyChangeCB(mockLatencyChangeCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
-    
+
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -1399,8 +1437,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAVLatencyChangeCB(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAVLatencyChangeCB(void) {
+
     gTestID = 28;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     // Step 1: Call dsHdmiInRegisterAVLatencyChangeCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterAVLatencyChangeCB(mockLatencyChangeCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -1443,6 +1483,7 @@ void mockAviContentCallback(dsHdmiInPort_t port, dsAviContentType_t avi_content_
  * 
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAviContentTypeChangeCB(void) {
+
     gTestID = 29;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -1452,7 +1493,7 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAviContentTypeChangeCB(void) {
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
 
-    // Step 2: Call dsHdmiInRegisterAviContentTypeChangeCB()
+    // Step 2: Call dsHdmiInRegisterAviContentTypeChangeCB() based on the number of input ports
     if (numInputPorts > 0) {
         // For sink devices
          UT_ASSERT_EQUAL(dsHdmiInRegisterAviContentTypeChangeCB(mockAviContentCallback), dsERR_NONE);
@@ -1490,8 +1531,10 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAviContentTypeChangeCB(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAviContentTypeChangeCB(void) {
+
     gTestID = 30;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     // Step 1: Call dsHdmiInRegisterAviContentTypeChangeCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterAviContentTypeChangeCB(mockAviContentCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -1536,6 +1579,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAviContentTypeChangeCB(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
+
     gTestID = 31;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -1548,7 +1592,6 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
 
     // Step 2: Check if HDMI ARC is supported based on the number of input ports
     if (numInputPorts > 0) {
-       
         // Step 3: Call dsIsHdmiARCPort() with valid input (dsHDMI_IN_PORT_0)
         UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_0, &isArcPort1), dsERR_NONE);
 
@@ -1598,16 +1641,17 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink(void) {
+
     gTestID = 32;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    bool isArcPort;
+
     // Step 1: Call dsIsHdmiARCPort() without initializing the HDMI input sub-system
     dsError_t result = dsIsHdmiARCPort(dsHDMI_IN_PORT_0, NULL);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
     // Step 2: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
-
-    bool isArcPort;
 
     // Step 3: Call dsIsHdmiARCPort() with invalid value (dsHDMI_IN_PORT_MAX)
     UT_ASSERT_EQUAL(dsIsHdmiARCPort(dsHDMI_IN_PORT_MAX, &isArcPort),dsERR_INVALID_PARAM);
@@ -1649,6 +1693,7 @@ void test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
+
     gTestID = 33;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -1663,7 +1708,7 @@ void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
-   
+
     // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
@@ -1682,10 +1727,10 @@ void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
         // Step 7: Compare the results and make sure they are the same
         UT_ASSERT_EQUAL(edidSize3, edidSize4);
         UT_ASSERT_EQUAL(memcmp(edidBytes3, edidBytes4, edidSize3),0);
-     } else {
+    } else {
         // Step 8: Call dsGetEDIDBytesInfo() with valid input for source devices
-	UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(dsHDMI_IN_PORT_0, edidBytes1, &edidSize1), dsERR_OPERATION_NOT_SUPPORTED);
-     }
+        UT_ASSERT_EQUAL(dsGetEDIDBytesInfo(dsHDMI_IN_PORT_0, edidBytes1, &edidSize1), dsERR_OPERATION_NOT_SUPPORTED);
+    }
 
     // Step 9: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
@@ -1722,9 +1767,9 @@ void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
+
     gTestID = 34;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-
     unsigned char* edidBytes = (unsigned char*) malloc(255);
     int edidSize;
 
@@ -1780,6 +1825,7 @@ void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
+
     gTestID = 35;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -1787,8 +1833,6 @@ void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
     unsigned char* spdInfo2 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st));
     unsigned char* spdInfo3 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st));
     unsigned char* spdInfo4 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st));
-
-    numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -1811,11 +1855,11 @@ void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
         // Step 7: Compare the results and make sure they are the same
         UT_ASSERT_EQUAL(memcmp(spdInfo3, spdInfo4,sizeof(struct dsSpd_infoframe_st)),0);
 
-     } else {
+    } else {
         // Step 8: Call dsGetHDMISPDInfo() with valid input for source devices 
         UT_ASSERT_EQUAL(dsGetHDMISPDInfo(dsHDMI_IN_PORT_0, spdInfo1), dsERR_OPERATION_NOT_SUPPORTED);
     }
-        
+
     // Step 9: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -1850,9 +1894,9 @@ void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink(void) {
+
     gTestID = 36;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-
     unsigned char* spdInfo1 = (unsigned char*) malloc(sizeof(struct dsSpd_infoframe_st)); 
 
     // Step 1: Call dsGetHDMISPDInfo() without initializing the HDMI input sub-system
@@ -1903,9 +1947,9 @@ void test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
+
     gTestID = 37;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-
     uint32_t ver14, ver20;
     uint8_t numInputPorts = 0;
 
@@ -1932,9 +1976,9 @@ void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
         UT_ASSERT_EQUAL(dsSetEdidVersion(dsHDMI_IN_PORT_2, ver14), dsERR_NONE);
     } else {
        // Step 7: Call dsSetEdidVersion() with valid values for source devices
-	UT_ASSERT_EQUAL(dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14), dsERR_OPERATION_NOT_SUPPORTED);
+       UT_ASSERT_EQUAL(dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14), dsERR_OPERATION_NOT_SUPPORTED);
     }
-    
+
     // Step 8: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -1964,11 +2008,11 @@ void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
+
     gTestID = 38;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-
     uint8_t ver14 = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/EdidVersions/0");
-   
+
     // Step 1: Call dsSetEdidVersion() without initializing the HDMI input sub-system
     dsError_t result = dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -1988,6 +2032,7 @@ void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
     // Step 6: Call dsSetEdidVersion() without initializing the HDMI input sub-system
     result = dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -2012,6 +2057,7 @@ void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
+
     gTestID = 39;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -2065,9 +2111,9 @@ void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink(void) {
+
     gTestID = 40;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-
     tv_hdmi_edid_version_t edid_version;
 
     // Step 1: Call dsGetEdidVersion() without initializing the HDMI input sub-system
@@ -2117,6 +2163,7 @@ void test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
+
     gTestID = 41;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -2125,7 +2172,7 @@ void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
-    
+
     // Step 2: Get the number of input ports from the profile file
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
     if (numInputPorts > 0) {
@@ -2177,10 +2224,12 @@ void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink(void) {
+
     gTestID = 42;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    // Step 1: Call dsGetAllmStatus() without initializing the HDMI input sub-system
     bool allm_status;
+
+    // Step 1: Call dsGetAllmStatus() without initializing the HDMI input sub-system
     dsError_t result = dsGetAllmStatus(dsHDMI_IN_PORT_0, &allm_status);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
@@ -2224,6 +2273,7 @@ void test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsGetSupportedGameFeaturesList_sink(void) {
+
     gTestID = 43;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -2275,10 +2325,12 @@ void test_l1_dsHdmiIn_positive_dsGetSupportedGameFeaturesList_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink(void) {
+
     gTestID = 44;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    // Step 1: Call dsGetSupportedGameFeaturesList() without initializing the HDMI input sub-system
     dsSupportedGameFeatureList_t supported_features;
+
+    // Step 1: Call dsGetSupportedGameFeaturesList() without initializing the HDMI input sub-system
     dsError_t result = dsGetSupportedGameFeaturesList(&supported_features);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_GENERAL);
 
@@ -2294,6 +2346,7 @@ void test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink(void) {
     // Step 5: Call dsGetSupportedGameFeaturesList() after terminating the HDMI input sub-system
     result = dsGetSupportedGameFeaturesList(&supported_features);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_GENERAL);
+
     UT_LOG("\n Out %s\n", __FUNCTION__); 
 }
 
@@ -2318,6 +2371,7 @@ void test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsGetAVLatency_sink(void) {
+
     gTestID = 45;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     int audioLatency1, videoLatency1;
@@ -2368,10 +2422,12 @@ void test_l1_dsHdmiIn_positive_dsGetAVLatency_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsGetAVLatency_sink(void) {
+
     gTestID = 46;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    // Step 1: Call dsGetAVLatency() without initializing the HDMI input sub-system
     int audioLatency, videoLatency;
+
+    // Step 1: Call dsGetAVLatency() without initializing the HDMI input sub-system
     dsError_t result = dsGetAVLatency(&audioLatency, &videoLatency);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
@@ -2415,6 +2471,7 @@ void test_l1_dsHdmiIn_negative_dsGetAVLatency_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
+
     gTestID = 47;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
@@ -2434,9 +2491,9 @@ void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
         UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, false), dsERR_NONE);
     } else {
         // Step 5:Call dsSetEdid2AllmSupport() with valid ports
-	UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, true), dsERR_OPERATION_NOT_SUPPORTED);
+        UT_ASSERT_EQUAL(dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, true), dsERR_OPERATION_NOT_SUPPORTED);
     }
-    
+
     // Step 6: Terminate the HDMI input using dsHdmiInTerm()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -2465,8 +2522,10 @@ void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink(void) {
+
     gTestID = 48;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     // Step 1: Call dsSetEdid2AllmSupport() without prior initialization of HDMI input
     dsError_t result = dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, true);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
@@ -2510,6 +2569,7 @@ void test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
+
     gTestID = 49;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     bool allmSupport1, allmSupport2;
@@ -2533,7 +2593,7 @@ void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
       // Step 5:Call dsGetEdid2AllmSupport() with valid ports
       UT_ASSERT_EQUAL(dsGetEdid2AllmSupport(dsHDMI_IN_PORT_0, &allmSupport1), dsERR_OPERATION_NOT_SUPPORTED);
     }
-   
+
     // Step 6: Terminate the HDMI input using dsHdmiInTerm()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -2563,9 +2623,12 @@ void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
  * 
  */
 void test_l1_dsHdmiIn_negative_dsGetEdid2AllmSupport_sink(void) {
+
     gTestID = 50;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     bool allmSupport;
+
+    // Step 1: Call dsGetEdid2AllmSupport() without initializing the HDMI input sub-system 
     dsError_t result = dsGetEdid2AllmSupport(dsHDMI_IN_PORT_0, &allmSupport);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_OPERATION_NOT_SUPPORTED);
 
@@ -2613,7 +2676,7 @@ int test_l1_dsHdmiIn_register ( void )
                 return -1;
             }
             source_type = 1;
-        }
+    }
     else if(!strncmp(gDeviceType, TEST_TYPE_SINK_VALUE, TEST_DS_DEVICE_TYPE_SIZE)) {
             // Create the test suite for sink type
             pSuite = UT_add_suite("[L1 dsHdmiIn - Sink]", NULL, NULL);
@@ -2622,11 +2685,11 @@ int test_l1_dsHdmiIn_register ( void )
                 return -1;
             }
             source_type = 0;
-        }
-        else {
+         }
+         else {
               UT_LOG_ERROR("Invalid platform type: %s", gDeviceType);
               return -1;
-        }
+         }
     }
     else {
         UT_LOG_ERROR("Failed to get the platform type");

--- a/src/test_l1_dsHdmiIn.c
+++ b/src/test_l1_dsHdmiIn.c
@@ -97,13 +97,13 @@ static bool extendedEnumsSupported=false; //Default to not supported
 
 /**
  * @brief Ensure dsHdmiInInit() correctly initializes the HDMI input sub-system during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 001@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -111,12 +111,12 @@ static bool extendedEnumsSupported=false; //Default to not supported
  * |02|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after initialization |
  * |03|Call dsHdmiInInit() again | | dsERR_NONE | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after initialization |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInInit(void) {
 
     gTestID = 1;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -130,31 +130,31 @@ void test_l1_dsHdmiIn_positive_dsHdmiInInit(void) {
     // Step 4: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInInit() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 002@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Call dsHdmiInInit() again without terminating the HDMI input sub-system | | dsERR_ALREADY_INITIALIZED | Should Pass |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  * @note Testing for the `dsERR_GENERAL` and `dsERR_RESOURCE_NOT_AVAILABLE` might be challenging since it requires a specific scenario where the attempted operation is not supported.
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInInit(void) {
 
     gTestID = 2;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -166,18 +166,18 @@ void test_l1_dsHdmiIn_negative_dsHdmiInInit(void) {
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInTerm() correctly terminates the HDMI input sub-system during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 003@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -185,12 +185,12 @@ void test_l1_dsHdmiIn_negative_dsHdmiInInit(void) {
  * |02|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after initialization |
  * |03|Call dsHdmiInInit() again | | dsERR_NONE | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after initialization |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInTerm(void) {
 
     gTestID = 3;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -204,18 +204,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInTerm(void) {
     // Step 4: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInTerm() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 004@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -223,14 +223,14 @@ void test_l1_dsHdmiIn_positive_dsHdmiInTerm(void) {
  * |02|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after initialization |
  * |04|Call dsHdmiInTerm() without initializing the HDMI input sub-system | dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_GENERAL` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInTerm(void) {
 
     gTestID = 4;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Call dsHdmiInTerm() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInTerm();
@@ -246,18 +246,18 @@ void test_l1_dsHdmiIn_negative_dsHdmiInTerm(void) {
     result = dsHdmiInTerm();
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInGetNumberOfInputs() correctly fetches the number of HDMI input ports during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 005@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -267,13 +267,13 @@ void test_l1_dsHdmiIn_negative_dsHdmiInTerm(void) {
  * |03|Retrieve the expected number of HDMI input ports from the profile file and compare it with the number obtained from dsHdmiInGetNumberOfInputs() |
  * |04|Call dsHdmiInGetNumberOfInputs() to fetch the number of HDMI input ports |dsERR_OPERATION_NOT_SUPPORTED |For source devices without HDMI input support | 
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetNumberOfInputs(void) {
 
     gTestID = 5;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
-    uint8_t numInputs;
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    uint8_t numInputs = 0;
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
@@ -295,18 +295,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetNumberOfInputs(void) {
     // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInGetNumberOfInputs() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 006@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -315,15 +315,15 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetNumberOfInputs(void) {
  * |03|Call dsHdmiInGetNumberOfInputs() with NULL as the parameter |pNumberOfinputs: NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInGetNumberOfInputs() after termination of the HDMI input sub-system |pNumberOfinputs: uint8_t*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInGetNumberOfInputs(void) {
 
     gTestID = 6;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
-    uint8_t numInputs;
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    uint8_t numInputs = 0;
 
     // Step 1: Call dsHdmiInGetNumberOfInputs() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInGetNumberOfInputs(&numInputs);
@@ -342,18 +342,18 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetNumberOfInputs(void) {
     result = dsHdmiInGetNumberOfInputs(&numInputs);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInGetStatus() correctly fetches the HDMI input port status during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 007@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -364,13 +364,13 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetNumberOfInputs(void) {
  * |05|Compare the returned values to make sure they are equal || Success | The values should be the same |
  * |06|Call dsHdmiInGetStatus() with valid pointer |dsHdmiInStatus_t*| dsERR_OPERATION_NOT_SUPPORTED | For source devices without HDMI input support |
  * |07|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
 
     gTestID = 7;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
-    dsHdmiInStatus_t status1, status2;
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    dsHdmiInStatus_t status1={0} , status2 = {0};
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
@@ -389,9 +389,9 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
         UT_ASSERT_EQUAL(status1.isPresented, status2.isPresented);
         UT_ASSERT_EQUAL(status1.activePort, status2.activePort);
         for (int i = 0; i < dsHDMI_IN_PORT_MAX; i++) {
-             UT_LOG("\n In %s Comparing isPresented:[%d,%d]\n", __FUNCTION__, status1.isPresented, status2.isPresented); 
-             UT_LOG("\n In %s Comparing activePort:[%d,%d]\n", __FUNCTION__, status1.activePort, status2.activePort); 
-             UT_LOG("\n In %s Comparing isPortConnected:[%d,%d]\n", __FUNCTION__, status1.isPortConnected[i], status2.isPortConnected[i]); 
+             UT_LOG("\n In %s Comparing isPresented:[%d,%d]\n", __FUNCTION__, status1.isPresented, status2.isPresented);
+             UT_LOG("\n In %s Comparing activePort:[%d,%d]\n", __FUNCTION__, status1.activePort, status2.activePort);
+             UT_LOG("\n In %s Comparing isPortConnected:[%d,%d]\n", __FUNCTION__, status1.isPortConnected[i], status2.isPortConnected[i]);
              UT_ASSERT_EQUAL(status1.isPortConnected[i], status2.isPortConnected[i]);
         }
     } else {
@@ -402,18 +402,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
     // Step 7: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInGetStatus() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 008@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -422,15 +422,15 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetStatus(void) {
  * |03|Call dsHdmiInGetStatus() with NULL as the parameter |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInGetStatus() after terminating the HDMI input sub-system |dsHdmiInStatus_t*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInGetStatus(void) {
 
     gTestID = 8;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
-    dsHdmiInStatus_t status;
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    dsHdmiInStatus_t status = {0};
 
     // Step 1: Call dsHdmiInGetStatus() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInGetStatus(&status);
@@ -449,18 +449,18 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetStatus(void) {
     result = dsHdmiInGetStatus(&status);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInSelectPort() correctly selects an HDMI input port during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 009@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -471,12 +471,12 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetStatus(void) {
  * |05|Call dsHdmiInSelectPort() |dsHDMI_IN_PORT_2, bool: false, dsVideoPlane_PRIMARY, bool false| dsERR_NONE | Port 2 should be selected |
  * |06||Call dsHdmiInSelectPort() | dsERR_OPERATION_NOT_SUPPORTED | Loop through the ports where HDMI input is not supported
  * |07|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
 
     gTestID = 9;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
@@ -498,29 +498,29 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
              UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_NONE);
        }
     } else {
-       
+
 	for (uint8_t i =  numInputPorts; i < dsHDMI_IN_PORT_MAX; i++)
         {
-             // Step 6: Call dsHdmiInSelectPort() 
+             // Step 6: Call dsHdmiInSelectPort()
     	     UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_PRIMARY, false), dsERR_OPERATION_NOT_SUPPORTED);
         }
     }
-     
+
     // Step 7: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInSelectPort() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 010@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -531,14 +531,14 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectPort(void) {
  * |05|Call dsHdmiInSelectPort() with invalid plane value |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_MAX, bool: true| dsERR_INVALID_PARAM | Should Pass |
  * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |07|Call dsHdmiInSelectPort() after terminating the HDMI input sub-system |dsHDMI_IN_PORT_0, bool: false, dsVideoPlane_PRIMARY, bool: false| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
 
     gTestID = 10;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
 
     // Step 1: Call dsHdmiInSelectPort() without initializing the HDMI input sub-system
@@ -558,7 +558,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
           // Step 5: Call dsHdmiInSelectPort() with an invalid plane value
           UT_ASSERT_EQUAL(dsHdmiInSelectPort(i, false, dsVideoPlane_MAX, false), dsERR_INVALID_PARAM);
     }
-	
+
     // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -566,18 +566,18 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
     result = dsHdmiInSelectPort(dsHDMI_IN_PORT_0, false, dsVideoPlane_PRIMARY, false);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_INVALID_PARAM);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInScaleVideo() correctly scales the HDMI input video during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 011@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -588,12 +588,12 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectPort(void) {
  * |05|Scale HDMI input video using dsHdmiInScaleVideo() |x=100, y=100, width=800, height=600| dsERR_NONE | Video should be scaled |
  * |06|Scale HDMI input video using dsHdmiInScaleVideo() |x=0, y=0, width=800, height=600| dsERR_OPERATION_NOT_SUPPORTED | For source devices without HDMI input support |
  * |07|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInScaleVideo(void) {
 
     gTestID = 11;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
@@ -618,18 +618,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInScaleVideo(void) {
     // Step 7: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInScaleVideo() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 012@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -644,14 +644,14 @@ void test_l1_dsHdmiIn_positive_dsHdmiInScaleVideo(void) {
  * |09|dsHdmiInScaleVideo() with out of bounds|x=20000, y=0, width=800, height=600| dsERR_INVALID_PARAM | Should Pass |
  * |10|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |11|dsHdmiInScaleVideo() after terminating the HDMI input sub-system |x=0, y=0, width=800, height=600| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInScaleVideo(void) {
 
     gTestID = 12;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Call dsHdmiInScaleVideo() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInScaleVideo(0, 0, 800, 600);
@@ -688,18 +688,18 @@ void test_l1_dsHdmiIn_negative_dsHdmiInScaleVideo(void) {
     result = dsHdmiInScaleVideo(0, 0, 800, 600);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInSelectZoomMode() correctly updates the zoom mode during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 013@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -709,12 +709,12 @@ void test_l1_dsHdmiIn_negative_dsHdmiInScaleVideo(void) {
  * |04|Call dsHdmiInSelectZoomMode() and loop through all valid dsVideoZoom_t |[Valid Zoom Mode]| dsERR_NONE | Zoom mode should be updated |
  * |05|Call dsHdmiInSelectZoomMode() updates the video zoom on the active HDMI input using the provided zoom |dsERR_OPERATION_NOT_SUPPORTED |For both sink and source devices without HDMI input support
  * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
 
     gTestID = 13;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
@@ -739,18 +739,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
     // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInSelectZoomMode() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 014@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -760,14 +760,14 @@ void test_l1_dsHdmiIn_positive_dsHdmiInSelectZoomMode_source(void) {
  * |04|Call dsHdmiInSelectZoomMode() with invalid value |dsVIDEO_ZOOM_MAX| dsERR_INVALID_PARAM | Should Pass |
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |06|Call dsHdmiInSelectZoomMode() without terminating the HDMI input sub-system |dsVIDEO_ZOOM_NONE| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source(void) {
 
     gTestID = 14;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Call dsHdmiInSelectZoomMode() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_NONE);
@@ -789,18 +789,18 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source(void) {
     result = dsHdmiInSelectZoomMode(dsVIDEO_ZOOM_NONE);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInGetCurrentVideoMode() correctly retrieves the current HDMI video mode during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 015@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -811,14 +811,14 @@ void test_l1_dsHdmiIn_negative_dsHdmiInSelectZoomMode_source(void) {
  * |05|Ensure returned values are the same| |Success| The values should be the same |
  * |06|dsHdmiInGetCurrentVideoMode() to get the current HDMI input video mode of the active port | dsERR_OPERATION_NOT_SUPPORTED| For source devices without HDMI input support
  * |07|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
 
     gTestID = 15;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
-    dsVideoPortResolution_t resolution1;
-    dsVideoPortResolution_t resolution2;
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    dsVideoPortResolution_t resolution1 = {0};
+    dsVideoPortResolution_t resolution2 = {0};
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
@@ -832,15 +832,15 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
         UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(&resolution2), dsERR_NONE);
 
         // Step 4: Ensure returned values are the same
-        UT_LOG("\n In %s Name: [%d,%d]\n", __FUNCTION__, resolution1.name, resolution2.name); 
+        UT_LOG("\n In %s Name: [%d,%d]\n", __FUNCTION__, resolution1.name, resolution2.name);
         UT_ASSERT_EQUAL(resolution1.name, resolution2.name);
-        UT_LOG("\n In %s pixelResolution: [%d,%d]\n", __FUNCTION__, resolution1.pixelResolution, resolution2.pixelResolution); 
+        UT_LOG("\n In %s pixelResolution: [%d,%d]\n", __FUNCTION__, resolution1.pixelResolution, resolution2.pixelResolution);
         UT_ASSERT_EQUAL(resolution1.pixelResolution, resolution2.pixelResolution);
-        UT_LOG("\n In %s aspectRatio: [%d,%d]\n", __FUNCTION__, resolution1.aspectRatio, resolution2.aspectRatio); 
-        UT_ASSERT_EQUAL(resolution1.aspectRatio, resolution2.aspectRatio); 
-        UT_LOG("\n In %s frameRate: [%d,%d]\n", __FUNCTION__, resolution1.frameRate, resolution2.frameRate); 
+        UT_LOG("\n In %s aspectRatio: [%d,%d]\n", __FUNCTION__, resolution1.aspectRatio, resolution2.aspectRatio);
+        UT_ASSERT_EQUAL(resolution1.aspectRatio, resolution2.aspectRatio);
+        UT_LOG("\n In %s frameRate: [%d,%d]\n", __FUNCTION__, resolution1.frameRate, resolution2.frameRate);
         UT_ASSERT_EQUAL(resolution1.frameRate, resolution2.frameRate);
-        UT_LOG("\n In %s interlaced: [%d,%d]\n", __FUNCTION__, resolution1.interlaced, resolution2.interlaced); 
+        UT_LOG("\n In %s interlaced: [%d,%d]\n", __FUNCTION__, resolution1.interlaced, resolution2.interlaced);
         UT_ASSERT_EQUAL(resolution1.interlaced, resolution2.interlaced);
     } else {
       // Step 6: Retrieve the current HDMI video mode using dsHdmiInGetCurrentVideoMode()
@@ -850,18 +850,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
     // Step 7: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInGetCurrentVideoMode() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 016@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -870,17 +870,17 @@ void test_l1_dsHdmiIn_positive_dsHdmiInGetCurrentVideoMode(void) {
  * |03|dsHdmiInGetCurrentVideoMode() with NULL `resolution` pointer |NULL} dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInGetCurrentVideoMode() after terminating the HDMI input sub-system |dsVideoPortResolution_t*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInGetCurrentVideoMode(void) {
 
     gTestID = 16;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Call dsHdmiInGetCurrentVideoMode() without initializing the HDMI input sub-system
-    dsVideoPortResolution_t resolution;
+    dsVideoPortResolution_t resolution = {0};
     dsError_t result = dsHdmiInGetCurrentVideoMode(&resolution);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
@@ -889,7 +889,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetCurrentVideoMode(void) {
 
     // Step 3: dsHdmiInGetCurrentVideoMode() with NULL `resolution` pointer
     UT_ASSERT_EQUAL(dsHdmiInGetCurrentVideoMode(NULL),dsERR_INVALID_PARAM);
-	
+
     // Step 4: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
@@ -897,7 +897,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInGetCurrentVideoMode(void) {
     result = dsHdmiInGetCurrentVideoMode(&resolution);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 void mockConnectCallback(dsHdmiInPort_t Port, bool isPortConnected){
@@ -906,25 +906,25 @@ void mockConnectCallback(dsHdmiInPort_t Port, bool isPortConnected){
 
 /**
  * @brief Ensure dsHdmiInRegisterConnectCB() correctly registers a callback during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 017@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Call dsHdmiInRegisterConnectCB() registers a callback based on the number of input ports from the profile file |dsHdmiInConnectCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterConnectCB(void) {
 
     gTestID = 17;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
@@ -943,18 +943,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterConnectCB(void) {
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInRegisterConnectCB() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 018@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -963,14 +963,14 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterConnectCB(void) {
  * |03|Call dsHdmiInRegisterConnectCB() with invalid input |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05| Call dsHdmiInRegisterConnectCB() after termination the HDMI input sub-system |dsHdmiInConnectCB_t| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterConnectCB(void) {
 
     gTestID = 18;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Call dsHdmiInRegisterConnectCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterConnectCB(mockConnectCallback);
@@ -989,7 +989,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterConnectCB(void) {
     result = dsHdmiInRegisterConnectCB(mockConnectCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 void mockSignalCallback(dsHdmiInPort_t port, dsHdmiInSignalStatus_t sigStatus){
@@ -998,25 +998,25 @@ void mockSignalCallback(dsHdmiInPort_t port, dsHdmiInSignalStatus_t sigStatus){
 
 /**
  * @brief Ensure dsHdmiInRegisterSignalChangeCB() correctly registers a callback during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 019@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Call dsHdmiInRegisterSignalChangeCB() based on the number of input ports from the profile file |dsHdmiInSignalChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterSignalChangeCB(void) {
 
     gTestID = 19;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
 
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
@@ -1030,25 +1030,25 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterSignalChangeCB(void) {
     	UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_NONE);
 
     } else {
-    	// For source devices  
+    	// For source devices
         UT_ASSERT_EQUAL(dsHdmiInRegisterSignalChangeCB(mockSignalCallback), dsERR_OPERATION_NOT_SUPPORTED);
     }
 
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInRegisterSignalChangeCB() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 020@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1057,14 +1057,14 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterSignalChangeCB(void) {
  * |03|Call dsHdmiInRegisterSignalChangeCB() with invalid input |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInRegisterSignalChangeCB() after terminating the HDMI input sub-system |dsHdmiInSignalChangeCB_t| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterSignalChangeCB(void) {
 
     gTestID = 20;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Call dsHdmiInRegisterSignalChangeCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterSignalChangeCB(mockSignalCallback);
@@ -1083,7 +1083,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterSignalChangeCB(void) {
     result = dsHdmiInRegisterSignalChangeCB(mockSignalCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 void mockStatusChangeCallback(dsHdmiInStatus_t inputStatus){
@@ -1092,25 +1092,25 @@ void mockStatusChangeCallback(dsHdmiInStatus_t inputStatus){
 
 /**
  * @brief Ensure dsHdmiInRegisterStatusChangeCB() correctly registers a callback during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 021@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Call dsHdmiInRegisterStatusChangeCB() based on the number of input ports from the profile file |dsHdmiInStatusChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterStatusChangeCB(void) {
 
     gTestID = 21;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
 
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
@@ -1130,18 +1130,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterStatusChangeCB(void) {
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInRegisterStatusChangeCB() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 022@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1150,9 +1150,9 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterStatusChangeCB(void) {
  * |03|Call dsHdmiInRegisterStatusChangeCB() with invalid input |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInRegisterStatusChangeCB() after termination the HDMI input sub-system |dsHdmiInStatusChangeCB_t| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterStatusChangeCB(void) {
 
@@ -1176,7 +1176,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterStatusChangeCB(void) {
     result = dsHdmiInRegisterStatusChangeCB(mockStatusChangeCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 void mockVideoModeUpdateCallback(dsHdmiInPort_t port, dsVideoPortResolution_t videoResolution){
@@ -1185,25 +1185,25 @@ void mockVideoModeUpdateCallback(dsHdmiInPort_t port, dsVideoPortResolution_t vi
 
 /**
  * @brief Ensure dsHdmiInRegisterVideoModeUpdateCB() correctly registers a callback during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 023@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Call dsHdmiInRegisterVideoModeUpdateCB() based on the number of input ports from the profile file |dsHdmiInVideoModeUpdateCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterVideoModeUpdateCB(void) {
 
     gTestID = 23;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
 
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
@@ -1224,18 +1224,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterVideoModeUpdateCB(void) {
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInRegisterVideoModeUpdateCB() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 024@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1244,14 +1244,14 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterVideoModeUpdateCB(void) {
  * |03|Call dsHdmiInRegisterVideoModeUpdateCB() with invalid input |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInRegisterVideoModeUpdateCB() after terminating the HDMI input sub-system | dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterVideoModeUpdateCB(void) {
 
     gTestID = 24;
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID); 
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     // Step 1: Call dsHdmiInRegisterVideoModeUpdateCB() without initializing the HDMI input sub-system
     dsError_t result = dsHdmiInRegisterVideoModeUpdateCB(mockVideoModeUpdateCallback);
@@ -1270,7 +1270,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterVideoModeUpdateCB(void) {
     result = dsHdmiInRegisterVideoModeUpdateCB(mockVideoModeUpdateCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 void mockALLMChangeCallback(dsHdmiInPort_t port, bool allm_mode){
@@ -1279,20 +1279,20 @@ void mockALLMChangeCallback(dsHdmiInPort_t port, bool allm_mode){
 
 /**
  * @brief Ensure dsHdmiInRegisterAllmChangeCB() correctly registers a callback during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 025@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Call dsHdmiInRegisterAllmChangeCB() based on the number of input ports from the profile file |dsHdmiInAllmChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAllmChangeCB(void) {
 
@@ -1318,18 +1318,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAllmChangeCB(void) {
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInRegisterAllmChangeCB() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 026@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1338,9 +1338,9 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAllmChangeCB(void) {
  * |03|Call dsHdmiInRegisterAllmChangeCB() with invalid input |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInRegisterAllmChangeCB() after terminating the HDMI input sub-system | dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAllmChangeCB(void) {
 
@@ -1364,7 +1364,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAllmChangeCB(void) {
     result = dsHdmiInRegisterAllmChangeCB(mockALLMChangeCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 void mockLatencyChangeCallback(int audio_latency, int video_latency){
@@ -1373,20 +1373,20 @@ void mockLatencyChangeCallback(int audio_latency, int video_latency){
 
 /**
  * @brief Ensure dsHdmiInRegisterAVLatencyChangeCB() correctly registers a callback during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 027@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Call dsHdmiInRegisterAVLatencyChangeCB() based on the number of input ports from the profile file |dsAVLatencyChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAVLatencyChangeCB(void) {
 
@@ -1412,18 +1412,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAVLatencyChangeCB(void) {
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInRegisterAVLatencyChangeCB() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 028@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1432,9 +1432,9 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAVLatencyChangeCB(void) {
  * |03|Call dsHdmiInRegisterAVLatencyChangeCB() with invalid input |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInRegisterAVLatencyChangeCB() after terminating the HDMI input sub-system |dsAVLatencyChangeCB_t| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note The return values dsERR_OPERATION_NOT_SUPPORTED and dsERR_GENERAL may be difficult to test in a simulated environment
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAVLatencyChangeCB(void) {
 
@@ -1458,7 +1458,7 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAVLatencyChangeCB(void) {
     result = dsHdmiInRegisterAVLatencyChangeCB(mockLatencyChangeCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 void mockAviContentCallback(dsHdmiInPort_t port, dsAviContentType_t avi_content_type){
@@ -1467,20 +1467,20 @@ void mockAviContentCallback(dsHdmiInPort_t port, dsAviContentType_t avi_content_
 
 /**
  * @brief Ensure dsHdmiInRegisterAviContentTypeChangeCB() correctly registers a callback during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 029@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
  * |01|Initialize the HDMI input sub-system using dsHdmiInInit() | | dsERR_NONE | Should Pass |
  * |02|Call dsHdmiInRegisterAviContentTypeChangeCB() based on the number of input ports from the profile file |dsHdmiInAviContentTypeChangeCB_t| dsERR_NONE | Callback should be registered |
  * |03|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAviContentTypeChangeCB(void) {
 
@@ -1506,18 +1506,18 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAviContentTypeChangeCB(void) {
     // Step 3: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsHdmiInRegisterAviContentTypeChangeCB() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 030@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1526,9 +1526,9 @@ void test_l1_dsHdmiIn_positive_dsHdmiInRegisterAviContentTypeChangeCB(void) {
  * |03|Call dsHdmiInRegisterAviContentTypeChangeCB() with invalid input |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsHdmiInRegisterAviContentTypeChangeCB() after terminating the HDMI input sub-system | dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_GENERAL` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAviContentTypeChangeCB(void) {
 
@@ -1552,18 +1552,18 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAviContentTypeChangeCB(void) {
     result = dsHdmiInRegisterAviContentTypeChangeCB(mockAviContentCallback);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsIsHdmiARCPort() correctly checks for an HDMI ARC port during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 031@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1576,14 +1576,15 @@ void test_l1_dsHdmiIn_negative_dsHdmiInRegisterAviContentTypeChangeCB(void) {
  * |07|Compare the values of steps 4 and 5 to make sure they equal one another || Success | The values should be equal |
  * |08|Call dsIsHdmiARCPort() with valid input |dsHDMI_IN_PORT_0, bool*| dsERR_OPERATION_NOT_SUPPORTED | for source devices
  * |09|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
 
     gTestID = 31;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
-    bool isArcPort1, isArcPort2;
+    bool isArcPort1  = false; 
+    bool isArcPort2  = false;
 
     numInputPorts = UT_KVP_PROFILE_GET_UINT8("dsHdmiIn/HdmiInputPort/numberOfPorts");
 
@@ -1615,7 +1616,7 @@ void test_l1_dsHdmiIn_positive_dsIsHdmiARCPort_sink(void) {
     // Step 9: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
@@ -1644,7 +1645,7 @@ void test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink(void) {
 
     gTestID = 32;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    bool isArcPort;
+    bool isArcPort = false;
 
     // Step 1: Call dsIsHdmiARCPort() without initializing the HDMI input sub-system
     dsError_t result = dsIsHdmiARCPort(dsHDMI_IN_PORT_0, NULL);
@@ -1701,10 +1702,10 @@ void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
     unsigned char* edidBytes2 = (unsigned char*) malloc(255);
     unsigned char* edidBytes3 = (unsigned char*) malloc(255);
     unsigned char* edidBytes4 = (unsigned char*) malloc(255);
-    int edidSize1;
-    int edidSize2;
-    int edidSize3;
-    int edidSize4;
+    int edidSize1 = 0;
+    int edidSize2 = 0;
+    int edidSize3 = 0;
+    int edidSize4 = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -1740,18 +1741,18 @@ void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
     free(edidBytes3);
     free(edidBytes4);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetEDIDBytesInfo() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 034@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1762,16 +1763,16 @@ void test_l1_dsHdmiIn_positive_dsGetEDIDBytesInfo_sink(void) {
  * |05|Call dsGetEDIDBytesInfo() with invalid value |dsHDMI_IN_PORT_0, unsigned char*, NULL| dsERR_INVALID_PARAM | Should Pass |
  * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |07|Call dsGetEDIDBytesInfo() after termination the HDMI input sub-system |dsHDMI_IN_PORT_0, unsigned char*, int*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
 
     gTestID = 34;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     unsigned char* edidBytes = (unsigned char*) malloc(255);
-    int edidSize;
+    int edidSize = 0;
 
     // Step 1: Call dsGetEDIDBytesInfo() without initializing the HDMI input sub-system
     dsError_t result = dsGetEDIDBytesInfo(dsHDMI_IN_PORT_0, edidBytes, &edidSize);
@@ -1798,18 +1799,18 @@ void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
 
     free(edidBytes);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetHDMISPDInfo() correctly retrieves the HDMI SPD information during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 035@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1822,7 +1823,7 @@ void test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink(void) {
  * |07|Compare values from step 4/5 and make sure they're the same || Success | The values should be the same |
  * |08|Call dsGetHDMISPDInfo() with valid input | dsHDMI_IN_PORT_0, unsigned char* | dsERR_OPERATION_NOT_SUPPORTED | For source devices
  * |09|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
 
@@ -1868,18 +1869,18 @@ void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
     free(spdInfo3);
     free(spdInfo4);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetHDMISPDInfo() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 036@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1889,9 +1890,9 @@ void test_l1_dsHdmiIn_positive_dsGetHDMISPDInfo_sink(void) {
  * |04|Call dsGetHDMISPDInfo() with invalid values |dsHDMI_IN_PORT_0, NULL| dsERR_INVALID_PARAM | Should Pass |
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |06|Call dsGetHDMISPDInfo() after terminating the HDMI input sub-system |dsHDMI_IN_PORT_0, unsigned char*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink(void) {
 
@@ -1926,13 +1927,13 @@ void test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink(void) {
 
 /**
  * @brief Ensure dsSetEdidVersion() correctly sets the EDID version during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 037@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -1944,13 +1945,14 @@ void test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink(void) {
  * |06|Call dsSetEdidVersion() with valid values |dsHDMI_IN_PORT_2, HDMI_EDID_VER_14| dsERR_NONE | Should set EDID version successfully |
  * |07|Call dsSetEdidVersion() with valid values | dsHDMI_IN_PORT_0, HDMI_EDID_VER_14 | dsERR_OPERATION_NOT_SUPPORTED | For source devices
  * |08|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
 
     gTestID = 37;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    uint32_t ver14, ver20;
+    uint32_t ver14 = 0;
+    uint32_t ver20 = 0;
     uint8_t numInputPorts = 0;
 
     ver14 = UT_KVP_PROFILE_GET_UINT32("dsHdmiIn/EdidVersions/0");
@@ -1982,18 +1984,18 @@ void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
     // Step 8: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsSetEdidVersion() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 038@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2003,9 +2005,9 @@ void test_l1_dsHdmiIn_positive_dsSetEdidVersion_sink(void) {
  * |04|Call dsSetEdidVersion() with invalid inputs |dsHDMI_IN_PORT_0, HDMI_EDID_VER_MAX| dsERR_INVALID_PARAM | Should Pass |
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |06|Call dsSetEdidVersion() without initializing the HDMI input sub-system |dsHDMI_IN_PORT_0, HDMI_EDID_VER_14| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
 
@@ -2033,18 +2035,18 @@ void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
     result = dsSetEdidVersion(dsHDMI_IN_PORT_0, ver14);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetEdidVersion() correctly retrieves the EDID version during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 039@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2054,14 +2056,15 @@ void test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink(void) {
  * |04|Compare the values from final two calls in step 2 and make sure they match || Success | The values should be the same |
  * |05|Call dsGetEdidVersion() with valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
  * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
 
     gTestID = 39;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
-    tv_hdmi_edid_version_t edid_version_1, edid_version_2;
+    tv_hdmi_edid_version_t edid_version_1 = dsERR_NONE;
+    tv_hdmi_edid_version_t edid_version_2 = dsERR_NONE;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -2085,18 +2088,18 @@ void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
     // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetEdidVersion() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 040@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2108,13 +2111,13 @@ void test_l1_dsHdmiIn_positive_dsGetEdidVersion_sink(void) {
  * |06|Call dsGetEdidVersion() without initializing the HDMI input sub-system |dsHDMI_IN_PORT_0, tv_hdmi_edid_version_t*| dsERR_NOT_INITIALIZED | Should Pass |
  * 
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink(void) {
 
     gTestID = 40;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    tv_hdmi_edid_version_t edid_version;
+    tv_hdmi_edid_version_t edid_version = dsERR_NONE;
 
     // Step 1: Call dsGetEdidVersion() without initializing the HDMI input sub-system
     dsError_t result = dsGetEdidVersion(dsHDMI_IN_PORT_0, &edid_version);
@@ -2136,18 +2139,18 @@ void test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink(void) {
     result = dsGetEdidVersion(dsHDMI_IN_PORT_0, &edid_version);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetAllmStatus() correctly retrieves the ALLM status during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 041@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2160,15 +2163,16 @@ void test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink(void) {
  * |07|Compare the results of steps 4/5 and make sure they are the same || Success | The returned values should be the same |
  * |08|Call dsGetAllmStatus() with valid inputs | dsHDMI_IN_PORT_0, bool*| dsERR_OPERATION_NOT_SUPPORTED | For source devices
  * |09|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
 
     gTestID = 41;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
-    bool allm_status_1, allm_status_2;
-    bool allm_status_3;
+    bool allm_status_1 = false;
+    bool allm_status_2 = false;
+    bool allm_status_3 = false;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -2198,18 +2202,18 @@ void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
     // Step 8: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetAllmStatus() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 042@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2219,15 +2223,15 @@ void test_l1_dsHdmiIn_positive_dsGetAllmStatus_sink(void) {
  * |04|Call dsGetAllmStatus() without valid inputs |dsHDMI_IN_PORT_0, NULL| dsERR_INVALID_PARAM | Should Pass |
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |06|Call dsGetAllmStatus() after termination the HDMI input sub-system |dsHDMI_IN_PORT_0, bool*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink(void) {
 
     gTestID = 42;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    bool allm_status;
+    bool allm_status = false;
 
     // Step 1: Call dsGetAllmStatus() without initializing the HDMI input sub-system
     dsError_t result = dsGetAllmStatus(dsHDMI_IN_PORT_0, &allm_status);
@@ -2249,18 +2253,18 @@ void test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink(void) {
     result = dsGetAllmStatus(dsHDMI_IN_PORT_0, &allm_status);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetSupportedGameFeaturesList() correctly retrieves the list of supported game features during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 043@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2270,14 +2274,14 @@ void test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink(void) {
  * |04|Call dsGetSupportedGameFeaturesList() with valid inputs and Comparing the results to the expected values defined in the test profile |
  * |05||Call dsGetSupportedGameFeaturesList() with valid inputs | dsERR_OPERATION_NOT_SUPPORTED |For source devices
  * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsGetSupportedGameFeaturesList_sink(void) {
 
     gTestID = 43;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     uint8_t numInputPorts = 0;
-    dsSupportedGameFeatureList_t supported_features_1;
+    dsSupportedGameFeatureList_t supported_features_1 = {0};
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInInit(), dsERR_NONE);
@@ -2300,18 +2304,18 @@ void test_l1_dsHdmiIn_positive_dsGetSupportedGameFeaturesList_sink(void) {
     // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetSupportedGameFeaturesList() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 044@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2320,15 +2324,15 @@ void test_l1_dsHdmiIn_positive_dsGetSupportedGameFeaturesList_sink(void) {
  * |03|Call dsGetSupportedGameFeaturesList() with invalid input |NULL| dsERR_INVALID_PARAM | Should Pass |
  * |04|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |05|Call dsGetSupportedGameFeaturesList() after termination the HDMI input sub-system |dsSupportedGameFeatureList_t*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink(void) {
 
     gTestID = 44;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    dsSupportedGameFeatureList_t supported_features;
+    dsSupportedGameFeatureList_t supported_features ={0};
 
     // Step 1: Call dsGetSupportedGameFeaturesList() without initializing the HDMI input sub-system
     dsError_t result = dsGetSupportedGameFeaturesList(&supported_features);
@@ -2347,18 +2351,18 @@ void test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink(void) {
     result = dsGetSupportedGameFeaturesList(&supported_features);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_GENERAL);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetAVLatency() correctly retrieves the current AV latency during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 045@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2368,13 +2372,14 @@ void test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink(void) {
  * |04|Call dsGetAVLatency() with valid input |int*, int*| dsERR_NONE | Should retrieve AV latency values successfully |
  * |05|Call dsGetAVLatency() with valid input | dsERR_OPERATION_NOT_SUPPORTED | For source devices
  * |06|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsGetAVLatency_sink(void) {
 
     gTestID = 45;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    int audioLatency1, videoLatency1;
+    int audioLatency1 =0;
+    int videoLatency1 =0;
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize the HDMI input sub-system using dsHdmiInInit()
@@ -2396,18 +2401,18 @@ void test_l1_dsHdmiIn_positive_dsGetAVLatency_sink(void) {
     // Step 6: Call dsHdmiInTerm() to ensure deinitialization
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetAVLatency() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 046@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2417,15 +2422,16 @@ void test_l1_dsHdmiIn_positive_dsGetAVLatency_sink(void) {
  * |04|Call dsGetAVLatency() with valid inputs |int*, NULL| dsERR_INVALID_PARAM | Should Pass |
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |06|Call dsGetAVLatency() after terminating the HDMI input sub-system |int*, int*| dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsGetAVLatency_sink(void) {
 
     gTestID = 46;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    int audioLatency, videoLatency;
+    int audioLatency =0; 
+    int	videoLatency =0;
 
     // Step 1: Call dsGetAVLatency() without initializing the HDMI input sub-system
     dsError_t result = dsGetAVLatency(&audioLatency, &videoLatency);
@@ -2447,18 +2453,18 @@ void test_l1_dsHdmiIn_negative_dsGetAVLatency_sink(void) {
     result = dsGetAVLatency(&audioLatency, &videoLatency);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsSetEdid2AllmSupport() sets the EDID ALLM support correctly during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 047@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2468,7 +2474,7 @@ void test_l1_dsHdmiIn_negative_dsGetAVLatency_sink(void) {
  * |04|Call dsSetEdid2AllmSupport() to disable EDID ALLM support | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: false | dsERR_NONE | Should Pass |
  * |05|Call dsSetEdid2AllmSupport() with valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
  * |06|Terminate the HDMI input using dsHdmiInTerm() | | dsERR_NONE | Clean up after test |
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
 
@@ -2497,18 +2503,18 @@ void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
     // Step 6: Terminate the HDMI input using dsHdmiInTerm()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsSetEdid2AllmSupport() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 048@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2517,7 +2523,7 @@ void test_l1_dsHdmiIn_positive_dsSetEdid2AllmSupport_sink(void) {
  * |03|Call dsSetEdid2AllmSupport() with an invalid HDMI port | iHdmiPort: dsHDMI_IN_PORT_MAX, allmSupport: true | dsERR_INVALID_PARAM | Should Pass |
  * |04|Terminate the HDMI input using dsHdmiInTerm() | | dsERR_NONE | Clean up after test |
  * |05|Call dsSetEdid2AllmSupport() after termination | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: true | dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported or has failed respectively.
  * 
  */
@@ -2543,18 +2549,18 @@ void test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink(void) {
     result = dsSetEdid2AllmSupport(dsHDMI_IN_PORT_0, true);
     CHECK_FOR_EXTENDED_ERROR_CODE(result, dsERR_NOT_INITIALIZED, dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetEdid2AllmSupport() gets the EDID ALLM support correctly during positive scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 049@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2564,15 +2570,16 @@ void test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink(void) {
  * |04|Compare the returned values from steps 2/3 and verify that they are the same |  | success | The values should be the same |
  * |05|Call dsGetEdid2AllmSupport() with  valid ports | dsERR_OPERATION_NOT_SUPPORTED | For source devices
  * |06|Terminate the HDMI input using dsHdmiInTerm() | | dsERR_NONE | Clean up after test |
- * 
+ *
  * @note Ensure that the device supports querying of the EDID ALLM feature before running this test.
- * 
+ *
  */
 void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
 
     gTestID = 49;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    bool allmSupport1, allmSupport2;
+    bool allmSupport1 = false; 
+    bool allmSupport2 = false;
     uint8_t numInputPorts = 0;
 
     // Step 1: Initialize HDMI input using dsHdmiInInit()
@@ -2597,18 +2604,18 @@ void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
     // Step 6: Terminate the HDMI input using dsHdmiInTerm()
     UT_ASSERT_EQUAL_FATAL(dsHdmiInTerm(), dsERR_NONE);
 
-    UT_LOG("\n Out %s\n", __FUNCTION__); 
+    UT_LOG("\n Out %s\n", __FUNCTION__);
 }
 
 /**
  * @brief Ensure dsGetEdid2AllmSupport() returns correct error codes during negative scenarios.
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 050@n
- * 
+ *
  * **Dependencies:** None@n
  * **User Interaction:** None
- * 
+ *
  * **Test Procedure:**@n
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|-----------|----------|--------------|-----|
@@ -2618,15 +2625,15 @@ void test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink(void) {
  * |04|Call dsGetEdid2AllmSupport() with invalid inputs | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: NULL | dsERR_INVALID_PARAM | Should Pass |
  * |05|Call dsHdmiInTerm() to ensure deinitialization | | dsERR_NONE | Clean up after test |
  * |06|Call dsGetEdid2AllmSupport() without initializing the HDMI input sub-system again | iHdmiPort: dsHDMI_IN_PORT_0, allmSupport: bool* | dsERR_NOT_INITIALIZED | Should Pass |
- * 
+ *
  * @note Testing for the `dsERR_OPERATION_NOT_SUPPORTED` and `dsERR_OPERATION_FAILED` might be challenging since it requires a specific scenario where the attempted operation is not supported or fails due to other reasons.
- * 
+ *
  */
 void test_l1_dsHdmiIn_negative_dsGetEdid2AllmSupport_sink(void) {
 
     gTestID = 50;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    bool allmSupport;
+    bool allmSupport = false;
 
     // Step 1: Call dsGetEdid2AllmSupport() without initializing the HDMI input sub-system 
     dsError_t result = dsGetEdid2AllmSupport(dsHDMI_IN_PORT_0, &allmSupport);
@@ -2744,12 +2751,12 @@ int test_l1_dsHdmiIn_register ( void )
         UT_add_test( pSuite, "dsGetEDIDBytesInfo_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetEDIDBytesInfo_sink );
         UT_add_test( pSuite, "dsGetHDMISPDInfo_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetHDMISPDInfo_sink );
         UT_add_test( pSuite, "dsSetEdidVersion_L1_negative" ,test_l1_dsHdmiIn_negative_dsSetEdidVersion_sink );
-	UT_add_test( pSuite, "dsGetEdidVersion_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink );
-	UT_add_test( pSuite, "dsGetAllmStatus_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink );
-	UT_add_test( pSuite, "dsGetSupportedGameFeaturesList_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink );
-	UT_add_test( pSuite, "dsGetAVLatency_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetAVLatency_sink );
-	UT_add_test( pSuite, "dsSetEdid2AllmSupport_l1_negative" ,test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink );
-	UT_add_test( pSuite2, "dsGetEdid2AllmSupport_l1_positive" ,test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink );
+        UT_add_test( pSuite, "dsGetEdidVersion_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetEdidVersion_sink );
+        UT_add_test( pSuite, "dsGetAllmStatus_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetAllmStatus_sink );
+        UT_add_test( pSuite, "dsGetSupportedGameFeaturesList_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetSupportedGameFeaturesList_sink );
+        UT_add_test( pSuite, "dsGetAVLatency_L1_negative" ,test_l1_dsHdmiIn_negative_dsGetAVLatency_sink );
+        UT_add_test( pSuite, "dsSetEdid2AllmSupport_l1_negative" ,test_l1_dsHdmiIn_negative_dsSetEdid2AllmSupport_sink );
+        UT_add_test( pSuite2, "dsGetEdid2AllmSupport_l1_positive" ,test_l1_dsHdmiIn_positive_dsGetEdid2AllmSupport_sink );
         UT_add_test( pSuite2, "dsGetEdid2AllmSupport_l1_negative" ,test_l1_dsHdmiIn_negative_dsGetEdid2AllmSupport_sink );
         UT_add_test( pSuite2, "dsIsHdmiARCPort_L1_negative" ,test_l1_dsHdmiIn_negative_dsIsHdmiARCPort_sink );
    }


### PR DESCRIPTION
1. Clean up unnecessary code in L1:

- Removed the unused variables, and macros and compiled with zero warnings.
- FATAL used in all tests is removed except for init and term APIs.
- Reviewed the usage of casting, no casting was needed.

2. Re-checked if any new API interface has been added recently and requires an L1 test case, no new API interface was found.