### PR TITLE
gh #126 Updating source yaml file for display

### DIFF
--- a/profiles/source/Source_4K_Display.yaml
+++ b/profiles/source/Source_4K_Display.yaml
@@ -1,6 +1,8 @@
 dsDisplay:
   Type: source
   Name: xione
+  Number_of_ports: 0
+  Video_Ports: []
   features:
     extendedEnumsSupported: false
   # dsVIDEO_ASPECT_RATIO_4x3 = 0x00,    ///< 4:3 aspect ratio

--- a/profiles/source/Source_4K_Display.yaml
+++ b/profiles/source/Source_4K_Display.yaml
@@ -1,7 +1,7 @@
 dsDisplay:
   Type: source
   Name: xione
-  Number_of_ports: 0
-  Video_Ports: []
+  Number_of_ports: 1
+  Video_Ports: [0x06] # dsVIDEOPORT_TYPE_HDMI
   features:
     extendedEnumsSupported: false

--- a/profiles/source/Source_4K_Display.yaml
+++ b/profiles/source/Source_4K_Display.yaml
@@ -5,7 +5,3 @@ dsDisplay:
   Video_Ports: []
   features:
     extendedEnumsSupported: false
-  # dsVIDEO_ASPECT_RATIO_4x3 = 0x00,    ///< 4:3 aspect ratio
-  # dsVIDEO_ASPECT_RATIO_16x9 = 0x01,   ///< 16:9 aspect ratio
-  # dsVIDEO_ASPECT_RATIO_MAX  = 0xFF    ///< Out of range
-  Aspect Ratio: 0x01 # 16:9


### PR DESCRIPTION
Updating the source yaml file for display as parsing error occured during testing.
For source devices, if source ports are zero and non of the tests runs for source device except init and term. So added 1 port in yaml and type as HDMI for source devices.