### PR TITLE
FIx Logic for setFPColor and getFP Color

### DIFF
--- a/profiles/sink/Sink_FPD.yaml
+++ b/profiles/sink/Sink_FPD.yaml
@@ -13,7 +13,7 @@ dsFPD:
         MAX_CYCLERATE : 2               # Maximum Rate at which LED is rotating during scrolling
         DEFAULT_COLOR_MODE : 0          # Color Mode of LED (Single(0) or Multicolored(1))
         supportedColors :
-        - dsFPD_COLOR_RED
+          - 0xFF0000                    # dsFPD_COLOR_RED
   7segement_display_Support : false
   SupportedLEDStates: 0x1FE
     #dsFPD_LED_DEVICE_NONE,                      ///< Default state

--- a/profiles/sink/Sink_FPD.yaml
+++ b/profiles/sink/Sink_FPD.yaml
@@ -12,6 +12,12 @@ dsFPD:
         DEFAULT_LEVELS : 10             # Default Brightness level for the FP text display
         MAX_CYCLERATE : 2               # Maximum Rate at which LED is rotating during scrolling
         DEFAULT_COLOR_MODE : 0          # Color Mode of LED (Single(0) or Multicolored(1))
+        # 0x0000FF      dsFPD_COLOR_BLUE   ///< Blue color LED
+        # 0x00FF00      dsFPD_COLOR_GREEN  ///< Green color LED
+        # 0xFF0000      dsFPD_COLOR_RED    ///< Red color LED
+        # 0xFFFFE0      dsFPD_COLOR_YELLOW ///< Yellow color LED
+        # 0xFF8C00      dsFPD_COLOR_ORANGE ///< Orange color LED
+        # 0xFFFFFF      dsFPD_COLOR_WHITE  ///< White color LED
         supportedColors :
           - 0xFF0000                    # dsFPD_COLOR_RED
   7segement_display_Support : false

--- a/profiles/sink/Sink_FPD.yaml
+++ b/profiles/sink/Sink_FPD.yaml
@@ -6,21 +6,35 @@ dsFPD:
   Number_of_Indicators: 1
   SupportedFPDIndicators :
       1 : #dsFPD_INDICATOR_POWER
+      #dsFPD_INDICATOR_MESSAGE          = 0x00,  ///< Message/Mail LED
+      #dsFPD_INDICATOR_POWER            = 0x01,    ///< Power LED
+      #dsFPD_INDICATOR_RECORD           = 0x02,   ///< Record LED
+      #dsFPD_INDICATOR_REMOTE           = 0x03,   ///< Remote LED
+      #dsFPD_INDICATOR_RFBYPASS         = 0x04, ///< RF Bypass LED
         Indicator_Type : 0x01 #dsFPD_INDICATOR_POWER
         MAX_BRIGHTNESS : 100            # Maximum brightness value of FPD LEDs
         MIN_BRIGHTNESS : 0              # Minimum brightness value of FPD LEDs
         DEFAULT_LEVELS : 10             # Default Brightness level for the FP text display
         MAX_CYCLERATE : 2               # Maximum Rate at which LED is rotating during scrolling
-        DEFAULT_COLOR_MODE : 0          # Color Mode of LED (Single(0) or Multicolored(1))
-        # 0x0000FF      dsFPD_COLOR_BLUE   ///< Blue color LED
-        # 0x00FF00      dsFPD_COLOR_GREEN  ///< Green color LED
-        # 0xFF0000      dsFPD_COLOR_RED    ///< Red color LED
-        # 0xFFFFE0      dsFPD_COLOR_YELLOW ///< Yellow color LED
-        # 0xFF8C00      dsFPD_COLOR_ORANGE ///< Orange color LED
-        # 0xFFFFFF      dsFPD_COLOR_WHITE  ///< White color LED
+        DEFAULT_COLOR_MODE : 0          # Color Mode of LED (Single(0) or Multicolored(1)), Single should provide with one single color
+        #dsFPD_COLOR_BLUE   0x0000FF///< Blue color LED
+        #dsFPD_COLOR_GREEN  0x00FF00///< Green color LED
+        #dsFPD_COLOR_RED    0xFF0000///< Red color LED
+        #dsFPD_COLOR_YELLOW 0xFFFFE0///< Yellow color LED
+        #dsFPD_COLOR_ORANGE 0xFF8C00///< Orange color LED
+        #dsFPD_COLOR_WHITE  0xFFFFFF///< White color LED
         supportedColors :
           - 0xFF0000                    # dsFPD_COLOR_RED
   7segement_display_Support : false
+#dsFPD_LED_DEVICE_NONE                    = 0x00,                    ///< Default state
+#dsFPD_LED_DEVICE_ACTIVE                  = 0x01,                  ///< Device is active
+#dsFPD_LED_DEVICE_STANDBY                 = 0x02,                 ///< Device is in standby mode
+#dsFPD_LED_DEVICE_WPS_CONNECTING          = 0x03,          ///< Device connecting to WPS
+#dsFPD_LED_DEVICE_WPS_CONNECTED           = 0x04,           ///< Device connected to WPS
+#dsFPD_LED_DEVICE_WPS_ERROR               = 0x05,               ///< Error when trying to connect to WPS
+#dsFPD_LED_DEVICE_FACTORY_RESET           = 0x06,           ///< Reset Device to factory base
+#dsFPD_LED_DEVICE_USB_UPGRADE             = 0x07,             ///< Updating from USB drive
+#dsFPD_LED_DEVICE_SOFTWARE_DOWNLOAD_ERROR = 0x08, ///< Error in downloading new software update
   SupportedLEDStates: 0x1FE
     #dsFPD_LED_DEVICE_NONE,                      ///< Default state
     #dsFPD_LED_DEVICE_ACTIVE,                    ///< Device is active

--- a/profiles/source/Source_FPD.yaml
+++ b/profiles/source/Source_FPD.yaml
@@ -12,6 +12,12 @@ dsFPD:
       DEFAULT_LEVELS : 1              # Default Brightness level for the FP text display
       MAX_CYCLERATE : 2               # Maximum Rate at which LED is rotating during scrolling
       DEFAULT_COLOR_MODE : 1          # Color Mode of LED (Single(0) or Multicolored(1))
+      # 0x0000FF      dsFPD_COLOR_BLUE   ///< Blue color LED
+      # 0x00FF00      dsFPD_COLOR_GREEN  ///< Green color LED
+      # 0xFF0000      dsFPD_COLOR_RED    ///< Red color LED
+      # 0xFFFFE0      dsFPD_COLOR_YELLOW ///< Yellow color LED
+      # 0xFF8C00      dsFPD_COLOR_ORANGE ///< Orange color LED
+      # 0xFFFFFF      dsFPD_COLOR_WHITE  ///< White color LED
       supportedColors :
         - 0x00FF00                    # dsFPD_COLOR_GREEN
         - 0xFF0000                    # dsFPD_COLOR_RED

--- a/profiles/source/Source_FPD.yaml
+++ b/profiles/source/Source_FPD.yaml
@@ -6,23 +6,37 @@ dsFPD:
   Number_of_Indicators: 1
   SupportedFPDIndicators :
     1: #dsFPD_INDICATOR_POWER
+      #dsFPD_INDICATOR_MESSAGE          = 0x00,  ///< Message/Mail LED
+      #dsFPD_INDICATOR_POWER            = 0x01,    ///< Power LED
+      #dsFPD_INDICATOR_RECORD           = 0x02,   ///< Record LED
+      #dsFPD_INDICATOR_REMOTE           = 0x03,   ///< Remote LED
+      #dsFPD_INDICATOR_RFBYPASS         = 0x04, ///< RF Bypass LED
       Indicator_Type : 0x01 #dsFPD_INDICATOR_POWER
       MAX_BRIGHTNESS : 100            # Maximum brightness value of FPD LEDs
       MIN_BRIGHTNESS : 0              # Minimum brightness value of FPD LEDs
       DEFAULT_LEVELS : 1              # Default Brightness level for the FP text display
       MAX_CYCLERATE : 2               # Maximum Rate at which LED is rotating during scrolling
       DEFAULT_COLOR_MODE : 1          # Color Mode of LED (Single(0) or Multicolored(1))
-      # 0x0000FF      dsFPD_COLOR_BLUE   ///< Blue color LED
-      # 0x00FF00      dsFPD_COLOR_GREEN  ///< Green color LED
-      # 0xFF0000      dsFPD_COLOR_RED    ///< Red color LED
-      # 0xFFFFE0      dsFPD_COLOR_YELLOW ///< Yellow color LED
-      # 0xFF8C00      dsFPD_COLOR_ORANGE ///< Orange color LED
-      # 0xFFFFFF      dsFPD_COLOR_WHITE  ///< White color LED
+      #dsFPD_COLOR_BLUE   0x0000FF///< Blue color LED
+      #dsFPD_COLOR_GREEN  0x00FF00///< Green color LED
+      #dsFPD_COLOR_RED    0xFF0000///< Red color LED
+      #dsFPD_COLOR_YELLOW 0xFFFFE0///< Yellow color LED
+      #dsFPD_COLOR_ORANGE 0xFF8C00///< Orange color LED
+      #dsFPD_COLOR_WHITE  0xFFFFFF///< White color LED
       supportedColors :
         - 0x00FF00                    # dsFPD_COLOR_GREEN
         - 0xFF0000                    # dsFPD_COLOR_RED
         - 0xFF8C00                    # dsFPD_COLOR_ORANGE
         - 0xFFFFFF                    # dsFPD_COLOR_WHITE
+#dsFPD_LED_DEVICE_NONE                    = 0x00,                    ///< Default state
+#dsFPD_LED_DEVICE_ACTIVE                  = 0x01,                  ///< Device is active
+#dsFPD_LED_DEVICE_STANDBY                 = 0x02,                 ///< Device is in standby mode
+#dsFPD_LED_DEVICE_WPS_CONNECTING          = 0x03,          ///< Device connecting to WPS
+#dsFPD_LED_DEVICE_WPS_CONNECTED           = 0x04,           ///< Device connected to WPS
+#dsFPD_LED_DEVICE_WPS_ERROR               = 0x05,               ///< Error when trying to connect to WPS
+#dsFPD_LED_DEVICE_FACTORY_RESET           = 0x06,           ///< Reset Device to factory base
+#dsFPD_LED_DEVICE_USB_UPGRADE             = 0x07,             ///< Updating from USB drive
+#dsFPD_LED_DEVICE_SOFTWARE_DOWNLOAD_ERROR = 0x08, ///< Error in downloading new software update
   SupportedLEDStates: 0x1FE
   #dsFPD_LED_DEVICE_NONE,                      ///< Default state
   #dsFPD_LED_DEVICE_ACTIVE,                    ///< Device is active

--- a/profiles/source/Source_FPD.yaml
+++ b/profiles/source/Source_FPD.yaml
@@ -3,6 +3,7 @@ dsFPD:
   Name: STB_FPD_1_Indicator
   features:
     extendedEnumsSupported: false
+  Number_of_Indicators: 1
   SupportedFPDIndicators :
     1: #dsFPD_INDICATOR_POWER
       Indicator_Type : 0x01 #dsFPD_INDICATOR_POWER
@@ -13,10 +14,10 @@ dsFPD:
       DEFAULT_COLOR_MODE : 0          # Color Mode of LED (Single(0) or Multicolored(1))
       MULTI_COLOR_MODE : 2
       supportedColors :
-      - dsFPD_COLOR_GREEN
-      - dsFPD_COLOR_RED
-      - dsFPD_COLOR_ORANGE
-      - dsFPD_COLOR_WHITE
+        - 0x00FF00                    # dsFPD_COLOR_GREEN
+        - 0xFF0000                    # dsFPD_COLOR_RED
+        - 0xFF8C00                    # dsFPD_COLOR_ORANGE
+        - 0xFFFFFF                    # dsFPD_COLOR_WHITE
   SupportedLEDStates: 0x1FE
   #dsFPD_LED_DEVICE_NONE,                      ///< Default state
   #dsFPD_LED_DEVICE_ACTIVE,                    ///< Device is active

--- a/profiles/source/Source_FPD.yaml
+++ b/profiles/source/Source_FPD.yaml
@@ -11,8 +11,7 @@ dsFPD:
       MIN_BRIGHTNESS : 0              # Minimum brightness value of FPD LEDs
       DEFAULT_LEVELS : 1              # Default Brightness level for the FP text display
       MAX_CYCLERATE : 2               # Maximum Rate at which LED is rotating during scrolling
-      DEFAULT_COLOR_MODE : 0          # Color Mode of LED (Single(0) or Multicolored(1))
-      MULTI_COLOR_MODE : 2
+      DEFAULT_COLOR_MODE : 1          # Color Mode of LED (Single(0) or Multicolored(1))
       supportedColors :
         - 0x00FF00                    # dsFPD_COLOR_GREEN
         - 0xFF0000                    # dsFPD_COLOR_RED

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -666,9 +666,9 @@ void test_l1_dsFPD_positive_dsSetFPBrightness (void)
         printf("\n In %s, Indicator: [%d]\n", __FUNCTION__, eIndicator);
 
         // Set the brightness of the LED
-        snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",eIndicator);
+        snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",i);
         minBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(minbuffer);
-        snprintf(maxbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MAX_BRIGHTNESS",eIndicator);
+        snprintf(maxbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MAX_BRIGHTNESS",i);
         maxBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(maxbuffer);
         dsFPDBrightness_t avgBrightness = (maxBrightness + minBrightness) / 2;
 
@@ -742,9 +742,9 @@ void test_l1_dsFPD_negative_dsSetFPBrightness (void)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
-        snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",eIndicator);
+        snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",i);
         minBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(minbuffer);
-        snprintf(maxbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MAX_BRIGHTNESS",eIndicator);
+        snprintf(maxbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MAX_BRIGHTNESS",i);
         maxBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(maxbuffer);
         dsFPDBrightness_t avgBrightness = (maxBrightness + minBrightness) / 2;
         result = dsSetFPBrightness(eIndicator, avgBrightness);
@@ -783,9 +783,9 @@ void test_l1_dsFPD_negative_dsSetFPBrightness (void)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
-        snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",eIndicator);
+        snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",i);
         minBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(minbuffer);
-        snprintf(maxbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MAX_BRIGHTNESS",eIndicator);
+        snprintf(maxbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MAX_BRIGHTNESS",i);
         maxBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(maxbuffer);
         dsFPDBrightness_t avgBrightness = (maxBrightness + minBrightness) / 2;
         result = dsSetFPBrightness(eIndicator, avgBrightness);
@@ -801,9 +801,9 @@ void test_l1_dsFPD_negative_dsSetFPBrightness (void)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
-        snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",eIndicator);
+        snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",i);
         minBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(minbuffer);
-        snprintf(maxbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MAX_BRIGHTNESS",eIndicator);
+        snprintf(maxbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MAX_BRIGHTNESS",i);
         maxBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(maxbuffer);
         dsFPDBrightness_t avgBrightness = (maxBrightness + minBrightness) / 2;
         result = dsSetFPBrightness(eIndicator, avgBrightness );

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -131,7 +131,7 @@ static int gTestID = 1;
 /* Global flags to support features */
 static bool extendedEnumsSupported=false; //Default to not supported
 
-static dsFPDColorDictionary_t dsFPColorMap =
+static dsFPDColorDictionary_t dsFPColorMap [dsFPD_COLOR_MAX] =
 {
     {"dsFPD_COLOR_BLUE",dsFPD_COLOR_BLUE},
     {"dsFPD_COLOR_GREEN",dsFPD_COLOR_GREEN},
@@ -139,7 +139,6 @@ static dsFPDColorDictionary_t dsFPColorMap =
     {"dsFPD_COLOR_YELLOW",dsFPD_COLOR_YELLOW},
     {"dsFPD_COLOR_ORANGE",dsFPD_COLOR_ORANGE},
     {"dsFPD_COLOR_WHITE",dsFPD_COLOR_WHITE},
-    {"dsFPD_COLOR_MAX",dsFPD_COLOR_MAX}
 };
 
 
@@ -147,11 +146,16 @@ static dsFPDColorDictionary_t dsFPColorMap =
 static dsFPDColor_t getColorFromString(char* colorName)
 {
     int count = 0;
+    dsFPDColor_t color = dsFPD_COLOR_WHITE;
     for (count = 0; count < ((sizeof(dsFPColorMap))/sizeof(dsFPColorMap[0])); count ++)
     {
-        if(!strncpy(colorName,dsFPColorMap[count].name,DS_FPD_KEY_SIZE))
-            return dsFPColorMap[count].color;
+        if(!strncpy(colorName,dsFPColorMap[count].name,DS_FPD_KEY_SIZE)){
+            color = dsFPColorMap[count].color;
+            break;
+        }
+
     }
+    return color;
 }
 /**
  * @brief Ensure dsFPInit() returns correct error codes during positive scenarios
@@ -1296,7 +1300,6 @@ void test_l1_dsFPD_negative_dsSetFPColor (void)
     char buffer[DS_FPD_KEY_SIZE];
     char colorName[DS_FPD_KEY_SIZE];
     int numOfSupportedColors =0;
-    dsFPDColor_t color;
     char supportedColorbuffer[DS_FPD_KEY_SIZE];
 
     // Step 01: Call dsSetFPColor() without initializing

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -1090,7 +1090,6 @@ void test_l1_dsFPD_negative_dsGetFPState (void)
     // Step 01: Call dsGetFPState() without initializing (dsFPInit() not called)
     count = UT_KVP_PROFILE_GET_UINT8("dsFPD/Number_of_Indicators");
     for (int i = 1; i <= count; i++)
-:w
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -78,13 +78,15 @@
 #include "stdbool.h"
 #include <ut_kvp_profile.h>
 
+static int gTestGroup = 1;
+static int gTestID = 1;
+
+/* Global flags to support features */
+static bool extendedEnumsSupported=false; //Default to not supported
 
 #define DS_FPD_KEY_SIZE 128
 #define UB_LINK_DURATION 500
 #define UB_LINK_ITERATIONS 10
-
-static int gTestGroup = 1;
-static int gTestID = 1;
 
 #define enableFPDIndicators(count) {\
     dsError_t result;\
@@ -121,10 +123,6 @@ static int gTestID = 1;
        UT_ASSERT_EQUAL( old, result );\
    }\
 }
-
-
-/* Global flags to support features */
-static bool extendedEnumsSupported=false; //Default to not supported
 
 /**
  * @brief Ensure dsFPInit() returns correct error codes during positive scenarios

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -1565,14 +1565,14 @@ void test_l1_dsFPD_negative_dsGetFPColor (void)
  * @note This test case is deprecated.
  * @note Valid indicators can retrieved from yaml file
  */
-void test_l1_dsFPD_positive_dsSetFPDMode (void)
+void test_l1_dsFPD_positive_dsSetFPDMode(void)
 {
     gTestID = 19;
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     dsError_t result;
     dsFPDIndicator_t eIndicator;
     char buffer[DS_FPD_KEY_SIZE];
-    uint8_t count =0;
+    uint8_t count = 0;
 
     // Step 01: Initialize using dsFPInit()
     result = dsFPInit();
@@ -1583,8 +1583,8 @@ void test_l1_dsFPD_positive_dsSetFPDMode (void)
     for (int i = 1; i <= count; i++)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
-        eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
-        UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__,  eIndicator);
+        eIndicator = (dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
+        UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__, eIndicator);
         result = dsSetFPState(eIndicator, dsFPD_STATE_ON);
         UT_ASSERT_EQUAL(result, dsERR_NONE);
     }
@@ -1600,8 +1600,8 @@ void test_l1_dsFPD_positive_dsSetFPDMode (void)
     for (int i = 1; i <= count; i++)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
-        eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
-        UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__,  eIndicator);
+        eIndicator = (dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
+        UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__, eIndicator);
         result = dsSetFPState(eIndicator, dsFPD_STATE_OFF);
         UT_ASSERT_EQUAL(result, dsERR_NONE);
     }
@@ -1609,7 +1609,7 @@ void test_l1_dsFPD_positive_dsSetFPDMode (void)
     // Step 05: Terminate using dsFPTerm()
     result = dsFPTerm();
     UT_ASSERT_EQUAL_FATAL(result, dsERR_NONE);
-    UT_LOG("\n Out  %s\n",__FUNCTION__);
+    UT_LOG("\n Out  %s\n", __FUNCTION__);
 }
 
 /**
@@ -3164,46 +3164,45 @@ static UT_test_suite_t * pSuite = NULL;
  *
  * @return int - 0 on success, otherwise failure
  */
-int test_l1_dsFPD_register ( void )
+int test_l1_dsFPD_register(void)
 {
-        /* add a suite to the registry */
-        pSuite = UT_add_suite( "[L1 dsFPD]", NULL, NULL );
+    /* add a suite to the registry */
+    pSuite = UT_add_suite("[L1 dsFPD]", NULL, NULL);
 
-        if ( NULL == pSuite )
-        {
-           return -1;
-        }
+    if (NULL == pSuite)
+    {
+        return -1;
+    }
 
+    UT_add_test(pSuite, "dsFPInit_L1_positive", test_l1_dsFPD_positive_dsFPInit);
+    UT_add_test(pSuite, "dsFPInit_L1_negative", test_l1_dsFPD_negative_dsFPInit);
+    UT_add_test(pSuite, "dsFPTerm_L1_positive", test_l1_dsFPD_positive_dsFPTerm);
+    UT_add_test(pSuite, "dsFPTerm_L1_negative", test_l1_dsFPD_negative_dsFPTerm);
+    UT_add_test(pSuite, "dsSetFPState_L1_positive", test_l1_dsFPD_positive_dsSetFPState);
+    UT_add_test(pSuite, "dsSetFPState_L1_negative", test_l1_dsFPD_negative_dsSetFPState);
+    UT_add_test(pSuite, "dsSetFPBlink_L1_positive", test_l1_dsFPD_positive_dsSetFPBlink);
+    UT_add_test(pSuite, "dsSetFPBlink_L1_negative", test_l1_dsFPD_negative_dsSetFPBlink);
+    UT_add_test(pSuite, "dsSetFPBrightness_L1_positive", test_l1_dsFPD_positive_dsSetFPBrightness);
+    UT_add_test(pSuite, "dsSetFPBrightness_L1_negative", test_l1_dsFPD_negative_dsSetFPBrightness);
+    UT_add_test(pSuite, "dsGetFPBrightness_L1_positive", test_l1_dsFPD_positive_dsGetFPBrightness);
+    UT_add_test(pSuite, "dsGetFPBrightness_L1_negative", test_l1_dsFPD_negative_dsGetFPBrightness);
+    UT_add_test(pSuite, "dsGetFPState_L1_positive", test_l1_dsFPD_positive_dsGetFPState);
+    UT_add_test(pSuite, "dsGetFPState_L1_negative", test_l1_dsFPD_negative_dsGetFPState);
+    UT_add_test(pSuite, "dsSetFPColor_L1_positive", test_l1_dsFPD_positive_dsSetFPColor);
+    UT_add_test(pSuite, "dsSetFPColor_L1_negative", test_l1_dsFPD_negative_dsSetFPColor);
+    UT_add_test(pSuite, "dsGetFPColor_L1_positive", test_l1_dsFPD_positive_dsGetFPColor);
+    UT_add_test(pSuite, "dsGetFPColor_L1_negative", test_l1_dsFPD_negative_dsGetFPColor);
+    UT_add_test(pSuite, "dsFPSetLEDState_L1_positive", test_l1_dsFPD_positive_dsFPSetLEDState);
+    UT_add_test(pSuite, "dsFPGetSupportedLEDStates_L1_positive", test_l1_dsFPD_positive_dsFPGetSupportedLEDStates);
+    UT_add_test(pSuite, "dsFPGetSupportedLEDStates_L1_negative", test_l1_dsFPD_negative_dsFPGetSupportedLEDStates);
+    UT_add_test(pSuite, "dsFPSetLEDState_L1_negative", test_l1_dsFPD_negative_dsFPSetLEDState);
+    UT_add_test(pSuite, "dsFPGetLEDState_L1_positive", test_l1_dsFPD_positive_dsFPGetLEDState);
+    UT_add_test(pSuite, "dsFPGetLEDState_L1_negative", test_l1_dsFPD_negative_dsFPGetLEDState);
 
-        UT_add_test( pSuite, "dsFPInit_L1_positive" ,test_l1_dsFPD_positive_dsFPInit );
-        UT_add_test( pSuite, "dsFPInit_L1_negative" ,test_l1_dsFPD_negative_dsFPInit );
-        UT_add_test( pSuite, "dsFPTerm_L1_positive" ,test_l1_dsFPD_positive_dsFPTerm );
-        UT_add_test( pSuite, "dsFPTerm_L1_negative" ,test_l1_dsFPD_negative_dsFPTerm );
-        UT_add_test( pSuite, "dsSetFPState_L1_positive" ,test_l1_dsFPD_positive_dsSetFPState );
-        UT_add_test( pSuite, "dsSetFPState_L1_negative" ,test_l1_dsFPD_negative_dsSetFPState );
-        UT_add_test( pSuite, "dsSetFPBlink_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBlink );
-        UT_add_test( pSuite, "dsSetFPBlink_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBlink );
-        UT_add_test( pSuite, "dsSetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBrightness );
-        UT_add_test( pSuite, "dsSetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBrightness );
-        UT_add_test( pSuite, "dsGetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsGetFPBrightness );
-        UT_add_test( pSuite, "dsGetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsGetFPBrightness );
-        UT_add_test( pSuite, "dsGetFPState_L1_positive" ,test_l1_dsFPD_positive_dsGetFPState );
-        UT_add_test( pSuite, "dsGetFPState_L1_negative" ,test_l1_dsFPD_negative_dsGetFPState );
-        UT_add_test( pSuite, "dsSetFPColor_L1_positive" ,test_l1_dsFPD_positive_dsSetFPColor );
-        UT_add_test( pSuite, "dsSetFPColor_L1_negative" ,test_l1_dsFPD_negative_dsSetFPColor );
-        UT_add_test( pSuite, "dsGetFPColor_L1_positive" ,test_l1_dsFPD_positive_dsGetFPColor );
-        UT_add_test( pSuite, "dsGetFPColor_L1_negative" ,test_l1_dsFPD_negative_dsGetFPColor );
-        UT_add_test( pSuite, "dsFPSetLEDState_L1_positive" ,test_l1_dsFPD_positive_dsFPSetLEDState );
-        UT_add_test( pSuite, "dsFPGetSupportedLEDStates_L1_positive" ,test_l1_dsFPD_positive_dsFPGetSupportedLEDStates );
-        UT_add_test( pSuite, "dsFPGetSupportedLEDStates_L1_negative" ,test_l1_dsFPD_negative_dsFPGetSupportedLEDStates );
-        UT_add_test( pSuite, "dsFPSetLEDState_L1_negative" ,test_l1_dsFPD_negative_dsFPSetLEDState );
-        UT_add_test( pSuite, "dsFPGetLEDState_L1_positive" ,test_l1_dsFPD_positive_dsFPGetLEDState );
-        UT_add_test( pSuite, "dsFPGetLEDState_L1_negative" ,test_l1_dsFPD_negative_dsFPGetLEDState );
-
-        extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "dsFPD/features/extendedEnumsSupported" );
+    extendedEnumsSupported = ut_kvp_getBoolField(ut_kvp_profile_getInstance(), "dsFPD/features/extendedEnumsSupported");
 
     return 0;
-} 
+}
 
 /** @} */ // End of DS_FPD_HALTEST_L1
 /** @} */ // End of DS_FPD_HALTEST

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -1304,7 +1304,7 @@ void test_l1_dsFPD_negative_dsSetFPColor (void)
         for (int j = 0; j < sizeof(dsFPAvailableColors)/sizeof(dsFPAvailableColors[0]); ++j)
         {
             bool isSupported = false;
-            for (int k = 1; k < numOfSupportedColors; ++k)
+            for (int k = 0; k < numOfSupportedColors; ++k)
             {
                 snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors/%d", i, k);
                 color = (dsFPDColor_t)UT_KVP_PROFILE_GET_UINT32(buffer);

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -1090,6 +1090,7 @@ void test_l1_dsFPD_negative_dsGetFPState (void)
     // Step 01: Call dsGetFPState() without initializing (dsFPInit() not called)
     count = UT_KVP_PROFILE_GET_UINT8("dsFPD/Number_of_Indicators");
     for (int i = 1; i <= count; i++)
+:w
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
@@ -3174,22 +3175,22 @@ int test_l1_dsFPD_register ( void )
         }
 
 
-    UT_add_test( pSuite, "dsFPInit_L1_positive" ,test_l1_dsFPD_positive_dsFPInit );
-    UT_add_test( pSuite, "dsFPInit_L1_negative" ,test_l1_dsFPD_negative_dsFPInit );
+        UT_add_test( pSuite, "dsFPInit_L1_positive" ,test_l1_dsFPD_positive_dsFPInit );
+        UT_add_test( pSuite, "dsFPInit_L1_negative" ,test_l1_dsFPD_negative_dsFPInit );
         UT_add_test( pSuite, "dsFPTerm_L1_positive" ,test_l1_dsFPD_positive_dsFPTerm );
         UT_add_test( pSuite, "dsFPTerm_L1_negative" ,test_l1_dsFPD_negative_dsFPTerm );
-    UT_add_test( pSuite, "dsSetFPState_L1_positive" ,test_l1_dsFPD_positive_dsSetFPState );
+        UT_add_test( pSuite, "dsSetFPState_L1_positive" ,test_l1_dsFPD_positive_dsSetFPState );
         UT_add_test( pSuite, "dsSetFPState_L1_negative" ,test_l1_dsFPD_negative_dsSetFPState );
-    UT_add_test( pSuite, "dsSetFPBlink_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBlink );
-    UT_add_test( pSuite, "dsSetFPBlink_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBlink );
-    UT_add_test( pSuite, "dsSetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBrightness );
-    UT_add_test( pSuite, "dsSetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBrightness );
-    UT_add_test( pSuite, "dsGetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsGetFPBrightness );
-    UT_add_test( pSuite, "dsGetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsGetFPBrightness );
-    UT_add_test( pSuite, "dsGetFPState_L1_positive" ,test_l1_dsFPD_positive_dsGetFPState );
-    UT_add_test( pSuite, "dsGetFPState_L1_negative" ,test_l1_dsFPD_negative_dsGetFPState );
-    UT_add_test( pSuite, "dsSetFPColor_L1_positive" ,test_l1_dsFPD_positive_dsSetFPColor );
-    UT_add_test( pSuite, "dsSetFPColor_L1_negative" ,test_l1_dsFPD_negative_dsSetFPColor );
+        UT_add_test( pSuite, "dsSetFPBlink_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBlink );
+        UT_add_test( pSuite, "dsSetFPBlink_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBlink );
+        UT_add_test( pSuite, "dsSetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBrightness );
+        UT_add_test( pSuite, "dsSetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBrightness );
+        UT_add_test( pSuite, "dsGetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsGetFPBrightness );
+        UT_add_test( pSuite, "dsGetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsGetFPBrightness );
+        UT_add_test( pSuite, "dsGetFPState_L1_positive" ,test_l1_dsFPD_positive_dsGetFPState );
+        UT_add_test( pSuite, "dsGetFPState_L1_negative" ,test_l1_dsFPD_negative_dsGetFPState );
+        UT_add_test( pSuite, "dsSetFPColor_L1_positive" ,test_l1_dsFPD_positive_dsSetFPColor );
+        UT_add_test( pSuite, "dsSetFPColor_L1_negative" ,test_l1_dsFPD_negative_dsSetFPColor );
         UT_add_test( pSuite, "dsGetFPColor_L1_positive" ,test_l1_dsFPD_positive_dsGetFPColor );
         UT_add_test( pSuite, "dsGetFPColor_L1_negative" ,test_l1_dsFPD_negative_dsGetFPColor );
         UT_add_test( pSuite, "dsFPSetLEDState_L1_positive" ,test_l1_dsFPD_positive_dsFPSetLEDState );

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -722,7 +722,7 @@ void test_l1_dsFPD_positive_dsSetFPBrightness (void)
  * |10|Attempt to set brightness after dsFPTerm() has been called|eIndicator: dsFPD_INDICATOR_POWER, eBrightness: 50 |dsERR_NOT_INITIALIZED|Should fail due to termination|
  *
  * @note Valid indicators can retrieved from yaml file
- * 
+ *
  */
 void test_l1_dsFPD_negative_dsSetFPBrightness (void)
 {
@@ -836,7 +836,7 @@ void test_l1_dsFPD_negative_dsSetFPBrightness (void)
  * |07|Terminate with dsFPTerm()| |dsERR_NONE|Ensure the system is terminated|
  *
  * @note Valid indicators can retrieved from yaml file
- * 
+ *
  */
 void test_l1_dsFPD_positive_dsGetFPBrightness (void)
 {
@@ -880,7 +880,7 @@ void test_l1_dsFPD_positive_dsGetFPBrightness (void)
     UT_ASSERT_EQUAL(brightness_power_indicator, brightness_all_indicators[indicator_power_index]);
 
     // Step 06: Set all valid indicators to dsFPD_STATE_OFF using dsSetFPState()
-    disableFPDIndicators(count);    
+    disableFPDIndicators(count);
 
     // Step 07: Terminate with dsFPTerm()
     result = dsFPTerm();
@@ -1075,7 +1075,7 @@ void test_l1_dsFPD_positive_dsGetFPState (void)
  * |08|Call dsGetFPState() after termination|eIndicator: dsFPD_INDICATOR_POWER, state: dsFPDState_t*|dsERR_NOT_INITIALIZED|Validate it checks for initialization even after termination|
  *
  * @note Valid indicators can retrieved from the yaml file
- * 
+ *
  */
 void test_l1_dsFPD_negative_dsGetFPState (void)
 {
@@ -1222,14 +1222,13 @@ void test_l1_dsFPD_positive_dsSetFPColor (void)
             if(colorMode == 0)
             {
                 UT_ASSERT_EQUAL(result, dsERR_OPERATION_NOT_SUPPORTED);
-            } 
+            }
             else
             {
                 UT_ASSERT_EQUAL(result, dsERR_NONE);
             }
         }
     }
-
     //Step 04: Set all valid indicators to dsFPD_STATE_OFF using dsSetFPState()
     disableFPDIndicators(count);
     // Step 05: Terminate with dsFPTerm()
@@ -1358,7 +1357,7 @@ void test_l1_dsFPD_negative_dsSetFPColor (void)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
-        
+
         result = dsSetFPColor(eIndicator, dsFPD_COLOR_WHITE);
         UT_ASSERT_EQUAL(result, dsERR_OPERATION_NOT_SUPPORTED);
 
@@ -1384,7 +1383,7 @@ void test_l1_dsFPD_negative_dsSetFPColor (void)
  *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 017@n
- * 
+ *
  * **Pre-Conditions:**@n
  * None.
  *
@@ -1417,11 +1416,12 @@ void test_l1_dsFPD_positive_dsGetFPColor(void)
     char supportedColorbuffer[DS_FPD_KEY_SIZE];
     bool isSupported = false;
     uint8_t count = 0;
+    uint8_t colorMode = 0;
 
     // Step 01: Initialize with dsFPInit()
     result = dsFPInit();
     UT_ASSERT_EQUAL_FATAL(result, dsERR_NONE);
-    
+
     // Step 02: Set all valid indicators to dsFPD_STATE_ON using dsSetFPState()
     count = UT_KVP_PROFILE_GET_UINT8("dsFPD/Number_of_Indicators");
     enableFPDIndicators(count);
@@ -1432,35 +1432,40 @@ void test_l1_dsFPD_positive_dsGetFPColor(void)
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator = (dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
         UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__, eIndicator);
-        result = dsGetFPColor(eIndicator, &retrievedColor);
-        UT_ASSERT_EQUAL(result, dsERR_NONE);
-        snprintf(supportedColorbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors", i);
-        numOfSupportedColors = UT_KVP_PROFILE_GET_LIST_COUNT(supportedColorbuffer);
-        for (int k = 0; k < numOfSupportedColors; ++k)
+        snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/DEFAULT_COLOR_MODE", i);
+        colorMode =(uint8_t)UT_KVP_PROFILE_GET_UINT32(buffer);
+
+        if(colorMode == 0)
         {
-            snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors/%d", i, k);
-            color = (dsFPDColor_t)UT_KVP_PROFILE_GET_UINT32(buffer);
-            if (retrievedColor == color)
-            {
-                isSupported = true;
-                break;
-            }
+            result = dsGetFPColor(eIndicator, &retrievedColor);
+            UT_ASSERT_EQUAL(result,dsERR_OPERATION_NOT_SUPPORTED);
         }
-        UT_ASSERT_TRUE(isSupported);
+        else{
+            result = dsGetFPColor(eIndicator, &retrievedColor);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
+
+            snprintf(supportedColorbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors", i);
+            numOfSupportedColors = UT_KVP_PROFILE_GET_LIST_COUNT(supportedColorbuffer);
+
+            isSupported = false;
+            for (int k = 0; k < numOfSupportedColors; ++k)
+            {
+                snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors/%d", i, k);
+                color = (dsFPDColor_t)UT_KVP_PROFILE_GET_UINT32(buffer);
+                if (retrievedColor == color)
+                {
+                    isSupported = true;
+                    break;
+                }
+            }
+            UT_ASSERT_TRUE(isSupported);
+
+            // Step 04: Call dsGetFPColor() second time and compare results
+            result = dsGetFPColor(eIndicator, &retryColor);
+            UT_ASSERT_EQUAL(result, dsERR_NONE);
+            UT_ASSERT_EQUAL(retrievedColor,retryColor);
+        }
     }
-    // Step 04: Call dsGetFPColor() twice and compare results
-    for (int i = 1; i <= count; i++)
-    {
-        snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
-        eIndicator = (dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
-        UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__, eIndicator);
-        result = dsGetFPColor(eIndicator, &retrievedColor);
-        UT_ASSERT_EQUAL(result, dsERR_NONE);
-        result = dsGetFPColor(eIndicator, &retryColor);
-        UT_ASSERT_EQUAL(result, dsERR_NONE);
-        UT_ASSERT_EQUAL(retrievedColor,retryColor);
-    }
-    
     // Step 05: Set all valid indicators to dsFPD_STATE_OFF using dsSetFPState()
     disableFPDIndicators(count);
 
@@ -2270,7 +2275,7 @@ void test_l1_dsFPD_negative_dsGetFPTextBrightness(void)
 
 /**
  * @brief Ensure dsFPEnableCLockDisplay() correctly enables/disables the clock display
- * 
+ *
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 029@n
  *
@@ -3105,7 +3110,7 @@ void test_l1_dsFPD_positive_dsFPGetLEDState(void)
     result = dsFPGetLEDState(&ledState1);
     UT_ASSERT_EQUAL(result, dsERR_NONE);
 
-    // Step 05: Compare the retrieved LED state with the expected value from the profile file 
+    // Step 05: Compare the retrieved LED state with the expected value from the profile file
     UT_ASSERT_KVP_EQUAL_PROFILE_UINT32(ledState1, "dsFPD/SupportedLEDStates");
 
     // Step 06: Set all valid indicators to dsFPD_STATE_OFF using dsSetFPState()

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -421,7 +421,7 @@ void test_l1_dsFPD_negative_dsSetFPState (void)
         bool isIndicatorValid = false;
         for (int j = 1; j <= count; ++j)
         {
-    	    snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", j);
+            snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", j);
             eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
             if (eIndicator == i)
             {
@@ -499,7 +499,7 @@ void test_l1_dsFPD_positive_dsSetFPBlink (void)
         UT_ASSERT_EQUAL(result, dsERR_NONE);
         result = dsSetFPBlink(eIndicator, UB_LINK_DURATION, UB_LINK_ITERATIONS);
         UT_ASSERT_EQUAL(result, dsERR_NONE);
-    	result = dsSetFPState(eIndicator, dsFPD_STATE_OFF);
+        result = dsSetFPState(eIndicator, dsFPD_STATE_OFF);
         UT_ASSERT_EQUAL(result, dsERR_NONE);
     }
 
@@ -740,7 +740,7 @@ void test_l1_dsFPD_negative_dsSetFPBrightness (void)
     count = UT_KVP_PROFILE_GET_UINT8("dsFPD/Number_of_Indicators");
     for(int i = 1; i <= count; i++)
     {
-	snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
+    snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
         snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",eIndicator);
         minBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(minbuffer);
@@ -759,7 +759,7 @@ void test_l1_dsFPD_negative_dsSetFPBrightness (void)
     // Step 04: Pass an invalid eBrightness parameter to dsSetFPBrightness()
     for(int i = 1; i <= count; i++)
     {
-	snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
+    snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
         UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__, eIndicator);
         result = dsSetFPState(eIndicator, dsFPD_STATE_ON);
@@ -1304,7 +1304,7 @@ void test_l1_dsFPD_negative_dsSetFPColor (void)
         for (int j = 0; j < sizeof(dsFPAvailableColors)/sizeof(dsFPAvailableColors[0]); ++j)
         {
             bool isSupported = false;
-            for (int k = 1; k < numOfSupportedColors; ++k)
+            for (int k = 0; k < numOfSupportedColors; ++k)
             {
                 snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors/%d", i, k);
                 color = (dsFPDColor_t)UT_KVP_PROFILE_GET_UINT32(buffer);
@@ -1408,7 +1408,7 @@ void test_l1_dsFPD_positive_dsGetFPColor(void)
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator = (dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
         UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__, eIndicator);
-	    result = dsGetFPColor(eIndicator, &retrievedColor);
+        result = dsGetFPColor(eIndicator, &retrievedColor);
         UT_ASSERT_EQUAL(result, dsERR_NONE);
         snprintf(supportedColorbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors", i);
         numOfSupportedColors = UT_KVP_PROFILE_GET_LIST_COUNT(supportedColorbuffer);
@@ -1430,9 +1430,9 @@ void test_l1_dsFPD_positive_dsGetFPColor(void)
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator = (dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
         UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__, eIndicator);
-	    result = dsGetFPColor(eIndicator, &retrievedColor);
+        result = dsGetFPColor(eIndicator, &retrievedColor);
         UT_ASSERT_EQUAL(result, dsERR_NONE);
-	    result = dsGetFPColor(eIndicator, &retryColor);
+        result = dsGetFPColor(eIndicator, &retryColor);
         UT_ASSERT_EQUAL(result, dsERR_NONE);
         UT_ASSERT_EQUAL(retrievedColor,retryColor);
     }
@@ -3174,22 +3174,22 @@ int test_l1_dsFPD_register ( void )
         }
 
 
-	UT_add_test( pSuite, "dsFPInit_L1_positive" ,test_l1_dsFPD_positive_dsFPInit );
-	UT_add_test( pSuite, "dsFPInit_L1_negative" ,test_l1_dsFPD_negative_dsFPInit );
+    UT_add_test( pSuite, "dsFPInit_L1_positive" ,test_l1_dsFPD_positive_dsFPInit );
+    UT_add_test( pSuite, "dsFPInit_L1_negative" ,test_l1_dsFPD_negative_dsFPInit );
         UT_add_test( pSuite, "dsFPTerm_L1_positive" ,test_l1_dsFPD_positive_dsFPTerm );
         UT_add_test( pSuite, "dsFPTerm_L1_negative" ,test_l1_dsFPD_negative_dsFPTerm );
-	UT_add_test( pSuite, "dsSetFPState_L1_positive" ,test_l1_dsFPD_positive_dsSetFPState );
+    UT_add_test( pSuite, "dsSetFPState_L1_positive" ,test_l1_dsFPD_positive_dsSetFPState );
         UT_add_test( pSuite, "dsSetFPState_L1_negative" ,test_l1_dsFPD_negative_dsSetFPState );
-	UT_add_test( pSuite, "dsSetFPBlink_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBlink );
-	UT_add_test( pSuite, "dsSetFPBlink_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBlink );
-	UT_add_test( pSuite, "dsSetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBrightness );
-	UT_add_test( pSuite, "dsSetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBrightness );
-	UT_add_test( pSuite, "dsGetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsGetFPBrightness );
-	UT_add_test( pSuite, "dsGetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsGetFPBrightness );
-	UT_add_test( pSuite, "dsGetFPState_L1_positive" ,test_l1_dsFPD_positive_dsGetFPState );
-	UT_add_test( pSuite, "dsGetFPState_L1_negative" ,test_l1_dsFPD_negative_dsGetFPState );
-	UT_add_test( pSuite, "dsSetFPColor_L1_positive" ,test_l1_dsFPD_positive_dsSetFPColor );
-	UT_add_test( pSuite, "dsSetFPColor_L1_negative" ,test_l1_dsFPD_negative_dsSetFPColor );
+    UT_add_test( pSuite, "dsSetFPBlink_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBlink );
+    UT_add_test( pSuite, "dsSetFPBlink_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBlink );
+    UT_add_test( pSuite, "dsSetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsSetFPBrightness );
+    UT_add_test( pSuite, "dsSetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsSetFPBrightness );
+    UT_add_test( pSuite, "dsGetFPBrightness_L1_positive" ,test_l1_dsFPD_positive_dsGetFPBrightness );
+    UT_add_test( pSuite, "dsGetFPBrightness_L1_negative" ,test_l1_dsFPD_negative_dsGetFPBrightness );
+    UT_add_test( pSuite, "dsGetFPState_L1_positive" ,test_l1_dsFPD_positive_dsGetFPState );
+    UT_add_test( pSuite, "dsGetFPState_L1_negative" ,test_l1_dsFPD_negative_dsGetFPState );
+    UT_add_test( pSuite, "dsSetFPColor_L1_positive" ,test_l1_dsFPD_positive_dsSetFPColor );
+    UT_add_test( pSuite, "dsSetFPColor_L1_negative" ,test_l1_dsFPD_negative_dsSetFPColor );
         UT_add_test( pSuite, "dsGetFPColor_L1_positive" ,test_l1_dsFPD_positive_dsGetFPColor );
         UT_add_test( pSuite, "dsGetFPColor_L1_negative" ,test_l1_dsFPD_negative_dsGetFPColor );
         UT_add_test( pSuite, "dsFPSetLEDState_L1_positive" ,test_l1_dsFPD_positive_dsFPSetLEDState );
@@ -3201,7 +3201,7 @@ int test_l1_dsFPD_register ( void )
 
         extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "dsFPD/features/extendedEnumsSupported" );
 
-	return 0;
+    return 0;
 } 
 
 /** @} */ // End of DS_FPD_HALTEST_L1

--- a/src/test_l1_dsFPD.c
+++ b/src/test_l1_dsFPD.c
@@ -740,7 +740,7 @@ void test_l1_dsFPD_negative_dsSetFPBrightness (void)
     count = UT_KVP_PROFILE_GET_UINT8("dsFPD/Number_of_Indicators");
     for(int i = 1; i <= count; i++)
     {
-    snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
+        snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
         snprintf(minbuffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/MIN_BRIGHTNESS",eIndicator);
         minBrightness =(dsFPDBrightness_t)UT_KVP_PROFILE_GET_UINT32(minbuffer);
@@ -759,7 +759,7 @@ void test_l1_dsFPD_negative_dsSetFPBrightness (void)
     // Step 04: Pass an invalid eBrightness parameter to dsSetFPBrightness()
     for(int i = 1; i <= count; i++)
     {
-    snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
+        snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator =(dsFPDIndicator_t)UT_KVP_PROFILE_GET_UINT32(buffer);
         UT_LOG("\n In %s , Indicator: [%d]\n", __FUNCTION__, eIndicator);
         result = dsSetFPState(eIndicator, dsFPD_STATE_ON);
@@ -1304,7 +1304,7 @@ void test_l1_dsFPD_negative_dsSetFPColor (void)
         for (int j = 0; j < sizeof(dsFPAvailableColors)/sizeof(dsFPAvailableColors[0]); ++j)
         {
             bool isSupported = false;
-            for (int k = 0; k < numOfSupportedColors; ++k)
+            for (int k = 1; k < numOfSupportedColors; ++k)
             {
                 snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors/%d", i, k);
                 color = (dsFPDColor_t)UT_KVP_PROFILE_GET_UINT32(buffer);

--- a/src/test_l2_dsFPD.c
+++ b/src/test_l2_dsFPD.c
@@ -462,20 +462,18 @@ void test_l2_dsFPD_SetFPstateON_Multi_SetColor(void)
         }
         else
         {
-            ret = dsSetFPState(eIndicator, dsFPD_STATE_OFF);
-            UT_LOG_DEBUG("dsSetFPState() returned status=%d", ret);
-            UT_ASSERT_EQUAL(ret, dsERR_NONE);
-            if (ret != dsERR_NONE)
-            {
-                UT_LOG_ERROR("dsSetFPState failed with status: %d", ret);
-                continue;
-            }
-            UT_LOG_DEBUG("The indicator supports only single color");
-            ret = dsGetFPColor(eIndicator, &getcolor);
-            UT_LOG_DEBUG("Invoking dsGetFPColor with eIndicator: %d", eIndicator);
-            UT_LOG_DEBUG("Color: %d and return status: %d", getcolor, ret);
-            UT_ASSERT_EQUAL(ret, dsERR_OPERATION_NOT_SUPPORTED);
+            UT_LOG_DEBUG("The indicator supports only single color and Set Color not supported");
         }
+
+        ret = dsSetFPState(eIndicator, dsFPD_STATE_OFF);
+        UT_LOG_DEBUG("dsSetFPState() returned status=%d", ret);
+        UT_ASSERT_EQUAL(ret, dsERR_NONE);
+        if (ret != dsERR_NONE)
+        {
+            UT_LOG_ERROR("dsSetFPState failed with status: %d", ret);
+            continue;
+        }
+
     }
 
     ret = dsFPTerm();

--- a/src/test_l2_dsFPD.c
+++ b/src/test_l2_dsFPD.c
@@ -78,36 +78,6 @@
 static int gTestGroup = 2;
 static int gTestID = 1;
 
-typedef struct dsFPDColorDictionary{
-    char name[DS_FPD_KEY_SIZE];
-    dsFPDColor_t color;
-}dsFPDColorDictionary_t;
-
-
-static dsFPDColorDictionary_t dsFPColorMap [dsFPD_COLOR_MAX] =
-{
-    {"dsFPD_COLOR_BLUE",dsFPD_COLOR_BLUE},
-    {"dsFPD_COLOR_GREEN",dsFPD_COLOR_GREEN},
-    {"dsFPD_COLOR_RED",dsFPD_COLOR_RED},
-    {"dsFPD_COLOR_YELLOW",dsFPD_COLOR_YELLOW},
-    {"dsFPD_COLOR_ORANGE",dsFPD_COLOR_ORANGE},
-    {"dsFPD_COLOR_WHITE",dsFPD_COLOR_WHITE},
-};
-
-static dsFPDColor_t getColorFromString(char* colorName)
-{
-    int count = 0;
-    dsFPDColor_t color = dsFPD_COLOR_WHITE;
-    for (count = 0; count < ((sizeof(dsFPColorMap))/sizeof(dsFPColorMap[0])); count ++)
-    {
-        if(!strncpy(colorName,dsFPColorMap[count].name,DS_FPD_KEY_SIZE)){
-            color = dsFPColorMap[count].color;
-            break;
-        }
-
-    }
-    return color;
-}
 /**
 * @brief This test function is designed to test the functionality of the Front Panel Display (FPD) indicators.
 *
@@ -148,7 +118,7 @@ void test_l2_dsFPD_SetFPstateON_SetBrightness(void)
 
     pInstance = ut_kvp_profile_getInstance();
     count = ut_kvp_getUInt32Field(pInstance,"dsFPD/Number_of_Indicators");
-    for (int i=0;i<count;i++)
+    for (int i=1;i<=count;i++)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator = ut_kvp_getUInt32Field( pInstance, buffer);
@@ -250,7 +220,7 @@ void test_l2_dsFPD_SetFPstateOFF_SetBrightness(void)
 
     pInstance = ut_kvp_profile_getInstance();
     count = ut_kvp_getListCount(pInstance,"dsFPD/Number_of_Indicators");
-    for (int i=0;i<count;i++)
+    for (int i=1;i<=count;i++)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator = ut_kvp_getUInt32Field( pInstance, buffer);
@@ -335,7 +305,7 @@ void test_l2_dsFPD_SetFPstateOFF_SetBlink(void)
 
     pInstance = ut_kvp_profile_getInstance();
     count = ut_kvp_getUInt32Field(pInstance,"dsFPD/Number_of_Indicators");
-    for (int i=0;i<count;i++)
+    for (int i=1;i<=count;i++)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator = ut_kvp_getUInt32Field( pInstance, buffer);
@@ -408,12 +378,10 @@ void test_l2_dsFPD_SetFPstateON_Multi_SetColor(void)
     dsFPDColor_t color;
     dsFPDColor_t getcolor;
     dsFPDIndicator_t eIndicator;
-    ut_kvp_status_t status;
     int count = 0;
     int mode = 0;
     int numOfSupportedColors = 0;
     char buffer[DS_FPD_KEY_SIZE];
-    char colorName[DS_FPD_KEY_SIZE];
     char colorbuffer[DS_FPD_KEY_SIZE];
     char supportedColorbuffer[DS_FPD_KEY_SIZE];
     ut_kvp_instance_t *pInstance = NULL;
@@ -470,13 +438,7 @@ void test_l2_dsFPD_SetFPstateON_Multi_SetColor(void)
             for (int j=0;j<numOfSupportedColors;j++)
             {
                 snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors/%d", i, j);
-                status = ut_kvp_getStringField( pInstance, buffer,colorName,UT_KVP_MAX_ELEMENT_SIZE);
-                if(status != UT_KVP_STATUS_SUCCESS)
-                {
-                    UT_LOG_ERROR("reading supported color failed with status: %d", status);
-                    continue;
-                }
-                color = getColorFromString(colorName); 
+                color = (dsFPDColor_t)ut_kvp_getUInt32Field( pInstance, buffer);
                 UT_LOG_DEBUG("Invoking dsSetFPColor with eIndicator: %d and color: 0x%X", eIndicator, color);
                 ret = dsSetFPColor(eIndicator, color);
                 UT_LOG_DEBUG("Return status: %d", ret);
@@ -544,7 +506,6 @@ void test_l2_dsFPD_SetFPstateOFF_SetColor(void)
     gTestID = 5;
     UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
-    ut_kvp_status_t status;
     dsError_t ret = dsERR_NONE;
     dsFPDState_t state;
     dsFPDColor_t eColor;
@@ -552,7 +513,6 @@ void test_l2_dsFPD_SetFPstateOFF_SetColor(void)
     int count = 0;
     int numOfSupportedColors = 0;
     char buffer[DS_FPD_KEY_SIZE];
-    char colorName[DS_FPD_KEY_SIZE];
     ut_kvp_instance_t *pInstance = NULL;
     char supportedColorbuffer[DS_FPD_KEY_SIZE];
 
@@ -599,13 +559,7 @@ void test_l2_dsFPD_SetFPstateOFF_SetColor(void)
         for (int j=0;j<numOfSupportedColors;j++)
         {
             snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors/%d", i, j);
-            status = ut_kvp_getStringField( pInstance, buffer,colorName,UT_KVP_MAX_ELEMENT_SIZE);
-            if(status != UT_KVP_STATUS_SUCCESS)
-            {
-                UT_LOG_ERROR("reading supported color failed with status: %d", status);
-                continue;
-            }
-            eColor = getColorFromString(colorName); 
+            eColor = (dsFPDColor_t)ut_kvp_getUInt32Field( pInstance, buffer);
             UT_LOG_DEBUG("Invoking dsSetFPColor with eIndicator: %d and color: %d", eIndicator, eColor);
             ret = dsSetFPColor(eIndicator, eColor);
             UT_LOG_DEBUG("Return status: %d", ret);
@@ -646,7 +600,6 @@ void test_l2_dsFPD_SetFPstateON_Single_SetColor(void)
     gTestID = 6;
     UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
-    ut_kvp_status_t status;
     dsError_t ret = dsERR_NONE;
     dsFPDState_t state;
     dsFPDColor_t color;
@@ -655,7 +608,6 @@ void test_l2_dsFPD_SetFPstateON_Single_SetColor(void)
     int mode = 0;
     int numOfSupportedColors = 0;
     char buffer[DS_FPD_KEY_SIZE];
-    char colorName[DS_FPD_KEY_SIZE];
     ut_kvp_instance_t *pInstance = NULL;
     char colorbuffer[DS_FPD_KEY_SIZE];
     char supportedColorbuffer[DS_FPD_KEY_SIZE];
@@ -668,7 +620,7 @@ void test_l2_dsFPD_SetFPstateON_Single_SetColor(void)
 
     pInstance = ut_kvp_profile_getInstance();
     count = ut_kvp_getUInt32Field(pInstance,"dsFPD/Number_of_Indicators");
-    for (int i=0;i<count;i++)
+    for (int i=1;i<=count;i++)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);
         eIndicator = ut_kvp_getUInt32Field( pInstance, buffer);
@@ -711,13 +663,7 @@ void test_l2_dsFPD_SetFPstateON_Single_SetColor(void)
             for (int j=0;j<numOfSupportedColors;j++)
             {
                 snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/supportedColors/%d", i, j);
-                status = ut_kvp_getStringField( pInstance, buffer,colorName,UT_KVP_MAX_ELEMENT_SIZE);
-                if(status != UT_KVP_STATUS_SUCCESS)
-                {
-                    UT_LOG_ERROR("reading supported color failed with status: %d", status);
-                    continue;
-                }
-                color = getColorFromString(colorName); 
+                color = (dsFPDColor_t)ut_kvp_getUInt32Field( pInstance, buffer);
                 UT_LOG_DEBUG("Invoking dsSetFPColor with eIndicator: %d and color: %d", eIndicator, color);
                 ret = dsSetFPColor(eIndicator, color);
                 UT_LOG_DEBUG("Return status: %d", ret);


### PR DESCRIPTION
fixing following issues.
1) Index for the color read was wrong. - corrected indexing.
2) Color was read as int32 even though it is provided as string in YAML. - created a method to convert string  to the color value.