### PR TITLE
Corrected the kvp function to read number of indicators

### DIFF
--- a/src/test_l2_dsFPD.c
+++ b/src/test_l2_dsFPD.c
@@ -219,7 +219,7 @@ void test_l2_dsFPD_SetFPstateOFF_SetBrightness(void)
     UT_ASSERT_EQUAL_FATAL(ret, dsERR_NONE);
 
     pInstance = ut_kvp_profile_getInstance();
-    count = ut_kvp_getListCount(pInstance,"dsFPD/Number_of_Indicators");
+    count = ut_kvp_getUInt32Field(pInstance,"dsFPD/Number_of_Indicators");
     for (int i=1;i<=count;i++)
     {
         snprintf(buffer, DS_FPD_KEY_SIZE, "dsFPD/SupportedFPDIndicators/%d/Indicator_Type", i);


### PR DESCRIPTION
L2_dsFPD_SetFPstateOFF_SetBrightness - To obtain the number of indicators, the straight variable is maintained in the YAML file. It is required to use that variable with the proper KVP function. Currently, the count KVP is used to read the number of indicator variables instead of int32, causing a mismatch and failure. Corrected the logic for the same.