### PR TITLE
gh #280 Updated profile,testcase for Dialog Enhancement

### DIFF
--- a/host/tests/L3_TestCases/dsAudio/dsAudio_test04_MS12DialogueEnhancer.py
+++ b/host/tests/L3_TestCases/dsAudio/dsAudio_test04_MS12DialogueEnhancer.py
@@ -51,9 +51,6 @@ class dsAudio_test04_MS12DialogueEnhancer(dsAudioHelperClass):
         self.qcID = '4'
         self.ms12DAPFeature = "DialogueEnhancer"
 
-        # List of dialogue enhance values for testing
-        self.dialogueEnhance = [0, 8, 16]
-
         super().__init__(self.testName, self.qcID, log)
 
     #TODO: Current version supports only manual verification.
@@ -64,7 +61,7 @@ class dsAudio_test04_MS12DialogueEnhancer(dsAudioHelperClass):
         Args:
             stream (str): The stream used for testing.
             port (str): The audio port to verify.
-            level (int): The Dialogue Enhancer level (0-16).
+            level (int): The Dialogue Enhancer Level ranges from 0 to 12(as per 2.6 IDK) or 0 to 16(as per 2.4.1 IDK).
             manual (bool): If True, prompts the user for verification. Defaults to False.
 
         Returns:
@@ -99,6 +96,12 @@ class dsAudio_test04_MS12DialogueEnhancer(dsAudioHelperClass):
                 if self.testdsAudio.getMS12DAPFeatureSupport(port, index, self.ms12DAPFeature):
                     # Enable the audio port
                     self.testdsAudio.enablePort(port, index)
+                    output  = self.testdsAudio.getDialogueEnhance(port, index)
+                    # Storing values in variables
+                    min_value = output['min']
+                    max_value = output['max']
+                    # List of dialogue enhance values for testing
+                    self.dialogueEnhance = [min_value, max_value/2, max_value]
 
                     for level in self.dialogueEnhance:
                         self.log.stepStart(f'MS12 {self.ms12DAPFeature} level:{level} Port:{port} Index:{index} Stream:{stream}')

--- a/host/tests/dsClasses/dsAudio.py
+++ b/host/tests/dsClasses/dsAudio.py
@@ -917,6 +917,26 @@ class dsAudioClass():
                 return entry['MS12_AudioProfiles']
         return []
 
+    def getDialogueEnhance(self, audio_port: str, port_index: int = 0):
+        """
+        Retrieves the list of supported MS12 audio profiles for the specified port.
+
+        Args:
+            audio_port (str): The name of the audio port.
+            port_index (int, optional): The index of the audio port. Defaults to 0.
+
+        Returns:
+            list: A list of supported MS12 audio profiles. If no profiles are found, returns an empty list.
+        """
+        if not self.ports:
+            return []
+
+        for entry in self.ports.values():
+            if (dsAudioPortType(entry['Typeid']).name == audio_port
+                and entry['Index'] == port_index):
+                return entry['dialog_enhancement_level']
+        return []
+
     def __del__(self):
         """
         Cleans up and de-initializes the dsAudio helper by stopping the test menu.

--- a/host/tests/dsClasses/dsAudio.py
+++ b/host/tests/dsClasses/dsAudio.py
@@ -919,14 +919,18 @@ class dsAudioClass():
 
     def getDialogueEnhance(self, audio_port: str, port_index: int = 0):
         """
-        Retrieves the list of supported MS12 audio profiles for the specified port.
+        Retrieves the dialogue enhancement levels supported by a specific audio port.
+
+        This method checks the available audio ports for the specified port type and index,
+        and returns the corresponding dialogue enhancement levels if they are defined.
 
         Args:
-            audio_port (str): The name of the audio port.
-            port_index (int, optional): The index of the audio port. Defaults to 0.
+            audio_port (str): The type of the audio port to query (e.g., HDMI, Optical).
+            port_index (int, optional): The index of the audio port to query. Defaults to 0.
 
         Returns:
-            list: A list of supported MS12 audio profiles. If no profiles are found, returns an empty list.
+            list: A list of dialogue enhancement levels available for the specified port.
+              Returns an empty list if no matching port or enhancement levels are found.
         """
         if not self.ports:
             return []

--- a/profiles/sink/Sink_4K_VideoPort.yaml
+++ b/profiles/sink/Sink_4K_VideoPort.yaml
@@ -6,7 +6,7 @@ dsVideoPort:
     Number_of_ports: 1
 
     #dsDISPLAY_COLORDEPTH_UNKNOWN = 0x0
-    #dsDISPLAY_COLORDEPTH_8BIT hal will return 8 
+    #dsDISPLAY_COLORDEPTH_8BIT hal will return 8
     #dsDISPLAY_COLORDEPTH_10BIT hal will return 10
     #dsDISPLAY_COLORDEPTH_12BIT hal will return 12
     color_depth: 10

--- a/profiles/sink/Sink_AudioSettings.yaml
+++ b/profiles/sink/Sink_AudioSettings.yaml
@@ -101,6 +101,9 @@ dsAudio:
             # dsAUDIO_ATMOS_ATMOSMETADATA              = 0x02, ///< capable of parsing ATMOS metadata
             # dsAUDIO_ATMOS_MAX                        = 0x03  ///< Out of range
             ATMOS_Capabilities: 0x02  # ATMOSMETADATA
+            dialog_enhancement_level:
+                min: 0
+                max: 12
 
         # Port Number to parse the port details
         2:
@@ -169,6 +172,9 @@ dsAudio:
             # dsAUDIOARCSUPPORT_ARC                    = 0x01,  ///< Audio Return Channel
             # dsAUDIOARCSUPPORT_eARC                   = 0x02,  ///< Enhanced Audio Return Channel
             Arc_Types: 0x01 # dsAUDIOARCSUPPORT_ARC
+            dialog_enhancement_level:
+                min: 0
+                max: 12
 
         # Port Number to parse the port details
         3:
@@ -233,6 +239,9 @@ dsAudio:
             # dsAUDIO_ATMOS_ATMOSMETADATA              = 0x02,  ///< capable of parsing ATMOS metadata
             # dsAUDIO_ATMOS_MAX                        = 0x03   ///< Out of range
             ATMOS_Capabilities: 0  # dsAUDIO_ATMOS_NOTSUPPORTED
+            dialog_enhancement_level:
+                min: 0
+                max: 12
 
         # Port Number to parse the port details
         4:
@@ -297,3 +306,6 @@ dsAudio:
             # dsAUDIO_ATMOS_ATMOSMETADATA              = 0x02,  ///< capable of parsing ATMOS metadata
             # dsAUDIO_ATMOS_MAX                        = 0x03   ///< Out of range
             ATMOS_Capabilities: 0  # dsAUDIO_ATMOS_NOTSUPPORTED
+            dialog_enhancement_level:
+                min: 0
+                max: 12

--- a/profiles/source/Source_4K_VideoPort.yaml
+++ b/profiles/source/Source_4K_VideoPort.yaml
@@ -6,7 +6,7 @@ dsVideoPort:
     Number_of_ports: 1
 
     #dsDISPLAY_COLORDEPTH_UNKNOWN = 0x0
-    #dsDISPLAY_COLORDEPTH_8BIT hal will return 8 
+    #dsDISPLAY_COLORDEPTH_8BIT hal will return 8
     #dsDISPLAY_COLORDEPTH_10BIT hal will return 10
     #dsDISPLAY_COLORDEPTH_12BIT hal will return 12
     color_depth: 8

--- a/profiles/source/Source_AudioSettings.yaml
+++ b/profiles/source/Source_AudioSettings.yaml
@@ -82,4 +82,7 @@ dsAudio:
             # dsAUDIO_ATMOS_NOTSUPPORTED               = 0x00,  ///< ATMOS audio not supported
             # dsAUDIO_ATMOS_SUPPORTED                  = 0x01,  ///< ATMOS audio supported
             ATMOS_Capabilities: 0x01  # dsAUDIO_ATMOS_SUPPORTED
+            dialog_enhancement_level:
+                min: 0
+                max: 12
 

--- a/src/test_dsAudio_parse_configuration.c
+++ b/src/test_dsAudio_parse_configuration.c
@@ -168,19 +168,14 @@ int test_dsAudio_parse_configuration()
         snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/ATMOS_Capabilities" , i+1);
         gDSAudioPortConfiguration[i].atmos_capabilites = ut_kvp_getUInt16Field( ut_kvp_profile_getInstance(), key_string  );
 
-        // comment code due to bug in : ut_kvp_fieldPresent unable to parse the %d
-        //if(ut_kvp_fieldPresent(ut_kvp_profile_getInstance(),"dsAudio/Ports/%d/dialog_enhancement_level"))
+        snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/dialog_enhancement_level" , i+1);
+        if(ut_kvp_fieldPresent(ut_kvp_profile_getInstance(),key_string))
         {
-            //if(ut_kvp_fieldPresent(ut_kvp_profile_getInstance(),"dsAudio/Ports/%d/dialog_enhancement_level/min"))
-            {
-                snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/dialog_enhancement_level/min" , i+1);
-                gDSAudioPortConfiguration[i].min_dialog_enhancement_level = ut_kvp_getUInt16Field( ut_kvp_profile_getInstance(), key_string );
-            }
-            //if(ut_kvp_fieldPresent(ut_kvp_profile_getInstance(),"dsAudio/Ports/%d/dialog_enhancement_level/max"))
-            {
-                snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/dialog_enhancement_level/max" , i+1);
-                gDSAudioPortConfiguration[i].max_dialog_enhancement_level = ut_kvp_getUInt16Field( ut_kvp_profile_getInstance(), key_string );
-            }
+            snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/dialog_enhancement_level/min" , i+1);
+            gDSAudioPortConfiguration[i].min_dialog_enhancement_level = ut_kvp_getUInt16Field( ut_kvp_profile_getInstance(), key_string );
+
+            snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/dialog_enhancement_level/max" , i+1);
+            gDSAudioPortConfiguration[i].max_dialog_enhancement_level = ut_kvp_getUInt16Field( ut_kvp_profile_getInstance(), key_string );
         }
 
          // loop to get supported compressions in array

--- a/src/test_dsAudio_parse_configuration.c
+++ b/src/test_dsAudio_parse_configuration.c
@@ -89,17 +89,17 @@ int test_dsAudio_parse_configuration()
 
     status = ut_kvp_getStringField(ut_kvp_profile_getInstance(), "dsAudio.Type", gDeviceType, TEST_DS_DEVICE_TYPE_SIZE);
 
-    if (status == UT_KVP_STATUS_SUCCESS ) 
+    if (status == UT_KVP_STATUS_SUCCESS )
     {
-        if (!strncmp(gDeviceType, TEST_TYPE_SOURCE_VALUE, TEST_DS_DEVICE_TYPE_SIZE)) 
+        if (!strncmp(gDeviceType, TEST_TYPE_SOURCE_VALUE, TEST_DS_DEVICE_TYPE_SIZE))
         {
             gSourceType = 1;
         }
-        else if(!strncmp(gDeviceType, TEST_TYPE_SINK_VALUE, TEST_DS_DEVICE_TYPE_SIZE)) 
+        else if(!strncmp(gDeviceType, TEST_TYPE_SINK_VALUE, TEST_DS_DEVICE_TYPE_SIZE))
         {
             gSourceType = 0;
         }
-        else 
+        else
         {
             UT_LOG_ERROR("Invalid platform type: %s", gDeviceType);
             return -1;
@@ -116,21 +116,22 @@ int test_dsAudio_parse_configuration()
 
     gAudioCapabilities    = UT_KVP_PROFILE_GET_UINT32("dsAudio/Audio_Capabilities");
     gDSAudioNumberOfPorts = UT_KVP_PROFILE_GET_UINT32("dsAudio/Number_of_supported_ports");
+    UT_LOG_DEBUG("gDSAudioNumberOfPorts =%d ",gDSAudioNumberOfPorts);
 
     gDSAudioPortConfiguration = (dsAudioPortConfiguration_t*) calloc(gDSAudioNumberOfPorts, sizeof(dsAudioPortConfiguration_t));
-    if(gDSAudioPortConfiguration == NULL) 
+    if(gDSAudioPortConfiguration == NULL)
     {
         UT_LOG_ERROR("Failed to allocate memory for audio configuration structure");
         return -1;
     }
 
-    for(int i = 0; i < gDSAudioNumberOfPorts; i++) 
+    for(int i = 0; i < gDSAudioNumberOfPorts; i++)
     {
 
         snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/Typeid" , i+1);
         gDSAudioPortConfiguration[i].typeid = ut_kvp_getUInt32Field(ut_kvp_profile_getInstance(), key_string);
 
-        if(gDSAudioPortConfiguration[i].typeid == dsAUDIOPORT_TYPE_HDMI_ARC) 
+        if(gDSAudioPortConfiguration[i].typeid == dsAUDIOPORT_TYPE_HDMI_ARC)
         {
             snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/Arc_Types" , i+1);
             gDSAudioPortConfiguration[i].arc_type = ut_kvp_getUInt32Field(ut_kvp_profile_getInstance(), key_string);
@@ -167,22 +168,37 @@ int test_dsAudio_parse_configuration()
         snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/ATMOS_Capabilities" , i+1);
         gDSAudioPortConfiguration[i].atmos_capabilites = ut_kvp_getUInt16Field( ut_kvp_profile_getInstance(), key_string  );
 
+        // comment code due to bug in : ut_kvp_fieldPresent unable to parse the %d
+        //if(ut_kvp_fieldPresent(ut_kvp_profile_getInstance(),"dsAudio/Ports/%d/dialog_enhancement_level"))
+        {
+            //if(ut_kvp_fieldPresent(ut_kvp_profile_getInstance(),"dsAudio/Ports/%d/dialog_enhancement_level/min"))
+            {
+                snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/dialog_enhancement_level/min" , i+1);
+                gDSAudioPortConfiguration[i].min_dialog_enhancement_level = ut_kvp_getUInt16Field( ut_kvp_profile_getInstance(), key_string );
+            }
+            //if(ut_kvp_fieldPresent(ut_kvp_profile_getInstance(),"dsAudio/Ports/%d/dialog_enhancement_level/max"))
+            {
+                snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/dialog_enhancement_level/max" , i+1);
+                gDSAudioPortConfiguration[i].max_dialog_enhancement_level = ut_kvp_getUInt16Field( ut_kvp_profile_getInstance(), key_string );
+            }
+        }
+
          // loop to get supported compressions in array
-        for(int j = 0; j < gDSAudioPortConfiguration[i].no_of_supported_compression; j++) 
+        for(int j = 0; j < gDSAudioPortConfiguration[i].no_of_supported_compression; j++)
         {
             snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/compressions/%d" , i+1 , j);
             gDSAudioPortConfiguration[i].supported_compressions[j] = ut_kvp_getUInt32Field(ut_kvp_profile_getInstance(), key_string);
         }
 
         //loop to get supported stereo modes in array
-        for(int j = 0; j < gDSAudioPortConfiguration[i].no_of_supported_stereo_mode; j++) 
+        for(int j = 0; j < gDSAudioPortConfiguration[i].no_of_supported_stereo_mode; j++)
         {
             snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/stereo_modes/%d" , i+1 , j);
             gDSAudioPortConfiguration[i].supported_stereo_mode[j] = ut_kvp_getUInt32Field(ut_kvp_profile_getInstance(), key_string);
         }
 
         // loop to get ms12 audio profiles
-        for(int j = 0; j < gDSAudioPortConfiguration[i].ms12_audioprofilecount; j++) 
+        for(int j = 0; j < gDSAudioPortConfiguration[i].ms12_audioprofilecount; j++)
         {
             snprintf(key_string, DS_AUDIO_KVP_SIZE, "dsAudio/Ports/%d/MS12_AudioProfiles/%d" , i+1 , j);
             status = ut_kvp_getStringField(ut_kvp_profile_getInstance(), key_string, gDSAudioPortConfiguration[i].ms12_audio_profiles[j], DS_AUDIO_MAX_MS12_PROFILE_LEN);
@@ -194,14 +210,14 @@ int test_dsAudio_parse_configuration()
 
 void test_dsAudio_parse_configuration_term()
 {
-    if(gDSAudioPortConfiguration) 
+    if(gDSAudioPortConfiguration)
     {
         free(gDSAudioPortConfiguration);
     }
 }
 
-/** @} */ // End of DS_HALTEST_PARSE_CONFIG_AUDIO
-/** @} */ // End of Device_Settings_HALTEST_PARSE_CONFIG
+/** @} */ // End of DS_Audio_HALTEST_PARSE_CONFIG
+/** @} */ // End of DS_Audio_HALTEST
 /** @} */ // End of Device_Settings_HALTEST
 /** @} */ // End of Device_Settings
 /** @} */ // End of HPK

--- a/src/test_dsAudio_parse_configuration.h
+++ b/src/test_dsAudio_parse_configuration.h
@@ -75,7 +75,7 @@
 
 #define DS_AUDIO_MOULE_NAME             "dsAudio"
 
-typedef struct 
+typedef struct
 {
     uint16_t typeid;
     uint16_t index;
@@ -92,6 +92,8 @@ typedef struct
     bool     isms11decode;
     int32_t  atmos_capabilites;
     int32_t  arc_type;
+    int32_t  min_dialog_enhancement_level;
+    int32_t  max_dialog_enhancement_level;
 }dsAudioPortConfiguration_t;
 
 /* Global variables */
@@ -106,7 +108,7 @@ void test_dsAudio_parse_configuration_term();
 
 #endif //__TEST_DSAUDIO_PARSE_CONFIG_H__
 
-/** @} */ // End of DS_Audio_HALTEST_PARSE_CONFIG
+/** @} */ // End of DS_Audio_HALTEST_PARSE_CONFIG_HEADER
 /** @} */ // End of DS_Audio_HALTEST
 /** @} */ // End of Device_Settings_HALTEST
 /** @} */ // End of Device_Settings

--- a/src/test_dsVideoDevice_parse_configuration.c
+++ b/src/test_dsVideoDevice_parse_configuration.c
@@ -91,47 +91,47 @@ int test_dsVideoDevice_parse_configuration()
     UT_LOG_DEBUG("gDSvideoDevice_NumVideoDevices: %d",gDSvideoDevice_NumVideoDevices);
 
     status = ut_kvp_getStringField(ut_kvp_profile_getInstance(), "dsVideoDevice/Type", gDeviceType, TEST_DS_DEVICE_TYPE_SIZE);
-    if (status == UT_KVP_STATUS_SUCCESS ) 
+    if (status == UT_KVP_STATUS_SUCCESS )
     {
-        if (!strncmp(gDeviceType, TEST_TYPE_SOURCE_VALUE, TEST_DS_DEVICE_TYPE_SIZE)) 
+        if (!strncmp(gDeviceType, TEST_TYPE_SOURCE_VALUE, TEST_DS_DEVICE_TYPE_SIZE))
         {
             gSourceType = 1;
         }
-        else if(!strncmp(gDeviceType, TEST_TYPE_SINK_VALUE, TEST_DS_DEVICE_TYPE_SIZE)) 
+        else if(!strncmp(gDeviceType, TEST_TYPE_SINK_VALUE, TEST_DS_DEVICE_TYPE_SIZE))
         {
             gSourceType = 0;
         }
-        else 
+        else
         {
             UT_LOG_ERROR("Invalid platform type: %s", gDeviceType);
             return -1;
         }
     }
-    else 
+    else
     {
         UT_LOG_ERROR("Failed to get the platform type");
         return -1;
     }
 
     status = ut_kvp_getStringField(ut_kvp_profile_getInstance(), "dsVideoDevice/Name", gDSVideoDeviceName, DS_VIDEO_DEVICE_NAME_SIZE);
-    if (status == UT_KVP_STATUS_SUCCESS ) 
+    if (status == UT_KVP_STATUS_SUCCESS )
     {
         UT_LOG_DEBUG("Device Type: %s, Device Name: %s", gDeviceType, gDSVideoDeviceName);
     }
-    else 
+    else
     {
         UT_LOG_ERROR("Failed to get the Device Name ");
         return -1;
     }
 
     gDSVideoDeviceConfiguration = (dsVideoDeviceConfiguration_t*) calloc(gDSvideoDevice_NumVideoDevices, sizeof(dsVideoDeviceConfiguration_t));
-    if(gDSVideoDeviceConfiguration == NULL) 
+    if(gDSVideoDeviceConfiguration == NULL)
     {
          UT_LOG_ERROR("Failed to allocate memory for Video Device configuration structure");
          return -1;
     }
 
-    for(int i = 0; i < gDSvideoDevice_NumVideoDevices; i++) 
+    for(int i = 0; i < gDSvideoDevice_NumVideoDevices; i++)
     {
         if(gSourceType == 1)
         {
@@ -140,7 +140,7 @@ int test_dsVideoDevice_parse_configuration()
             UT_LOG_DEBUG("NoOfSupportedDFCs: %d",gDSVideoDeviceConfiguration[i].NoOfSupportedDFCs);
 
             // loop to get supported SupportedDFCs in array
-            for(int j = 0; j < gDSVideoDeviceConfiguration[i].NoOfSupportedDFCs; j++) 
+            for(int j = 0; j < gDSVideoDeviceConfiguration[i].NoOfSupportedDFCs; j++)
             {
                 snprintf(key_string, DS_VIDEO_DEVICE_KVP_SIZE, "dsVideoDevice/Device/%d/SupportedDFCs/%d" , i+1 , j);
                 gDSVideoDeviceConfiguration[i].SupportedDFCs[j] = (dsVideoZoom_t)ut_kvp_getUInt32Field(ut_kvp_profile_getInstance(), key_string);
@@ -165,15 +165,15 @@ int test_dsVideoDevice_parse_configuration()
             gDSVideoDeviceConfiguration[i].NoOfSupportedDFR = ut_kvp_getListCount(ut_kvp_profile_getInstance(), key_string);
             UT_LOG_DEBUG("NoOfSupportedDFR: %d ",gDSVideoDeviceConfiguration[i].NoOfSupportedDFR);
             // loop to get supported SupportedDFR in array
-            for(int j = 0; j < gDSVideoDeviceConfiguration[i].NoOfSupportedDFR; j++) 
+            for(int j = 0; j < gDSVideoDeviceConfiguration[i].NoOfSupportedDFR; j++)
             {
                 snprintf(key_string, DS_VIDEO_DEVICE_KVP_SIZE, "dsVideoDevice/Device/%d/SupportedDisplayFramerate/%d" , i+1 , j);
                 status = ut_kvp_getStringField(ut_kvp_profile_getInstance(), key_string, gDSVideoDeviceConfiguration[i].SupportedDisplayFramerate[j], sizeof(gDSVideoDeviceConfiguration[i].SupportedDisplayFramerate[j]));
-                if (status == UT_KVP_STATUS_SUCCESS ) 
+                if (status == UT_KVP_STATUS_SUCCESS )
                 {
                     UT_LOG_DEBUG("SupportedDisplayFramerate: %s ",gDSVideoDeviceConfiguration[i].SupportedDisplayFramerate[j]);
                 }
-                else 
+                else
                 {
                     UT_LOG_ERROR("Failed to get the platform Device SupportedDisplayFramerate");
                     return -1;
@@ -207,7 +207,7 @@ int test_dsVideoDevice_parse_configuration()
 /* Free Parse Video Device Configuration */
 void test_dsVideoDevice_parse_configuration_term()
 {
-    if(gDSVideoDeviceConfiguration) 
+    if(gDSVideoDeviceConfiguration)
     {
         free(gDSVideoDeviceConfiguration);
     }

--- a/src/test_l1_dsAudio.c
+++ b/src/test_l1_dsAudio.c
@@ -975,6 +975,9 @@ void test_l1_dsAudio_positive_dsSetDialogEnhancement(void)
     // Step 02: Get the port handle for all supported audio ports
     for (int i = 0; i < gDSAudioNumberOfPorts; i++)
     {
+        min_de_level = gDSAudioPortConfiguration[i].min_dialog_enhancement_level;
+        max_de_level = gDSAudioPortConfiguration[i].max_dialog_enhancement_level;
+
         if (gDSAudioPortConfiguration[i].ms12_capabilites & 0x04)
         {
             result = dsGetAudioPort(gDSAudioPortConfiguration[i].typeid, gDSAudioPortConfiguration[i].index, &handle);

--- a/src/test_l2_dsAudio.c
+++ b/src/test_l2_dsAudio.c
@@ -411,7 +411,7 @@ void test_l2_dsAudio_SetAndGetDialogEnhancement(void)
             continue;
         }
 
-        for (level = 0; level <= 16; level++) {
+        for (level = gDSAudioPortConfiguration[port].min_dialog_enhancement_level; level <= gDSAudioPortConfiguration[port].max_dialog_enhancement_level; level++) {
             UT_LOG_DEBUG("Invoking dsSetDialogEnhancement() with handle: %p and level: %d", handle, level);
             ret = dsSetDialogEnhancement(handle, level);
             UT_ASSERT_EQUAL(ret, dsERR_NONE);


### PR DESCRIPTION
### Issue ###
Dialog Enhancement level varies between different SDK and IDK, this becomes a specific challenge as we don't have specific interface that can point what SDK doe's the platform support. 

For now, the Level ranges from 0 to 12(as per 2.6 IDK) or 0 to 16(as per 2.4.1 IDK) as per the header files

### Resolution ###
For now, the upper layers are looking for a level that can satisfies all the SDK and IDK's that has been used on the platforms.  As a intermediate workaround, the support of the dialog enhancement will be validated with the dialog level value defined in configuration file and it is made platform dependent.  The user needs to include this value as part of the configuration file and this will be used as part of test to validate the dialogue enhancement levels. 