### PR TITLE
gh #294 Modified the callback prints for L3 dsVideoPort_test1

### DIFF
--- a/host/tests/L3_TestCases/dsVideoPort/dsVideoPort_test1_VerifyVideoContent_Format_Callback.py
+++ b/host/tests/L3_TestCases/dsVideoPort/dsVideoPort_test1_VerifyVideoContent_Format_Callback.py
@@ -102,7 +102,11 @@ class dsVideoPort_test1_VerifyVideoContent_Format_Callback(dsVideoPortHelperClas
                 result = self.testdsVideoPort.read_Callbacks("Video Format Callback dsHDRStandard_t:")
 
                 if format not in "TechnicolorPrime":
-                    self.log.stepResult(self.find_VideoFormat_Status(result, f'dsHDRSTANDARD_{format}'),f'{format} VideoFormat Callback found')
+                    result = self.find_VideoFormat_Status(result, f'dsHDRSTANDARD_{format}')
+                    if result:
+                        self.log.stepResult(result,f'{format} VideoFormat Callback found')
+                    else:
+                        self.log.stepResult(result,f'{format} VideoFormat Callback Not found')
 
                 if format not in ["NONE", "TechnicolorPrime"]:
                     # Stop the stream playback


### PR DESCRIPTION
for dsVideoPort_test1_VerifyVideoContent_Format_Callback.py print is wrong when the Callback is not found.
Modified the callback prints to print callback is not found if the callback fails.