### PR TITLE
gh #301 Updated dsAudio Supported ARC types for disconnected state

### DIFF
--- a/host/tests/dsClasses/dsAudio.py
+++ b/host/tests/dsClasses/dsAudio.py
@@ -765,9 +765,9 @@ class dsAudioClass():
         typeStatusPattern = r"Result dsGetSupportedARCTypes\(IN:handle:\[.*\], OUT:types:\[(dsAUDIOARCSUPPORT_\w+)\]\)"
         type = self.searchPattern(result, typeStatusPattern)
 
-        if "eARC" in type:
+        if type == "dsAUDIOARCSUPPORT_eARC":
             return "eARC"
-        elif "ARC" in type :
+        elif type == "dsAUDIOARCSUPPORT_ARC":
             return "ARC"
         else:
             return "NONE"


### PR DESCRIPTION
For L3 dsAudio_test15_ARCPort.py test, ARC port type is failing for disconnected state as type match case is returning ARC instead of NONE as typeStatusPattern is already having keyword ARC (dsAUDIOARCSUPPORT_NONE).

Modified the match case to return the correct ARC port type.