### PR TITLE
gh #341 L3 dsDisplay event callbacks matchcase update

### DIFF
--- a/host/tests/L3_TestCases/dsDisplay/dsDisplay_test01_VerifyDisplayConnectCallBackTest.py
+++ b/host/tests/L3_TestCases/dsDisplay/dsDisplay_test01_VerifyDisplayConnectCallBackTest.py
@@ -47,7 +47,7 @@ class dsDisplay_test01_VerifyDisplayConnectCallBackTest(dsDisplayHelperClass):
             None.
         """
         # Class variables
-        self.testEvents = ["CONNECT", "DISCONNECT", "RXSENSE_ON", "RXSENSE_OFF", "HDCPPROTOCOL_CHANGE"]
+        self.testEvents = ["dsDISPLAY_EVENT_CONNECTED", "dsDISPLAY_EVENT_DISCONNECTED", "dsDISPLAY_RXSENSE_ON", "dsDISPLAY_RXSENSE_OFF", "dsDISPLAY_HDCPPROTOCOL_CHANGE"]
         self.testName  = "test01_VerifyDisplayConnectCallBackTest"
         self.qcID = '1'
         super().__init__(self.testName, self.qcID, log)
@@ -88,8 +88,12 @@ class dsDisplay_test01_VerifyDisplayConnectCallBackTest(dsDisplayHelperClass):
             for event in self.testEvents:
                 self.log.stepStart(f'Test Display Event {event} for the Port {port}')
                 self.testRaiseDisplayEvent(port, event,True)
-                status = self.testdsDisplay.getDisplayEventFromCallback()
-                result = status and event in status
+                eventsGenerated = self.testdsDisplay.getDisplayEventFromCallback()
+                result = False
+                for eventgen in eventsGenerated:
+                    if event == eventgen:
+                        result = True
+                        break
                 self.log.stepResult(result, f'Test Display Event {event} for the Port {port}')
 
         #Terminate dsDisplay Module

--- a/host/tests/dsClasses/dsDisplay.py
+++ b/host/tests/dsClasses/dsDisplay.py
@@ -246,14 +246,14 @@ class dsDisplayClass():
         Args:
             None
         Returns:
-            str: The display event type (e.g., 'dsVIDEO_EVENT_CONNECTED').
-            None: If no matching event status is found.
+            str: List of display events.
+            empty list: If no matching event status is found.
         """
 
         result = self.testSession.read_until("Display EventCallback(IN:handle:")
-        callpattern = r"Display EventCallback\(IN:handle:\[.*\], dsDisplayEvent_t:\[(\w+)\]"
-        status = self.searchPattern(result, callpattern)
-        return status
+        pattern = r"Display EventCallback\(IN:.*?dsDisplayEvent_t:\[([^\]]+)\]"
+        events = re.findall(pattern, result)
+        return events
 
     def terminate(self):
         """


### PR DESCRIPTION
The dsDisplay.py script currently searches for a single matching line in the generated callbacks to identify Display Event Callbacks.

With the recent implementation for the dsRegisterDisplayEventCallback API (https://ccp.sys.comcast.net/browse/RDKEVD-497), multiple callbacks are receiving now for HDMI connection and disconnection events. 

To accurately identify the required callback, have updated the Python class and test file to process all generated callback lines instead of matching just one.