### PR TITLE
gh #348 dsVideoPort L3 SetResolution properly assign the interlace value to bool

### DIFF
--- a/src/test_l3_dsVideoPort.c
+++ b/src/test_l3_dsVideoPort.c
@@ -638,20 +638,21 @@ void dsVideoPort_SetResolution()
     scanf("%d", &choice);
     readAndDiscardRestOfLine(stdin);
     setResolution.interlaced = (choice == dsVIDEO_SCANMODE_INTERLACED);
+    interlaced = choice;
 
     UT_LOG_INFO("Calling dsSetResolution(IN:Handle:[0x%0X],In:dsVideoPortResolution_t(dsVideoResolution_t:[%s]) ", gHandle,\
                     UT_Control_GetMapString(dsVideoResolutionMappingTable, setResolution.pixelResolution));
     UT_LOG_INFO("dsVideoAspectRatio_t:[%s],dsVideoStereoScopicMode_t:[%s])",UT_Control_GetMapString(dsVideoAspectRatioMappingTable, setResolution.aspectRatio),\
                          UT_Control_GetMapString(dsVideoStereoScopicModeMappingTable, setResolution.stereoScopicMode));
     UT_LOG_INFO("dsVideoFrameRate_t:[%s],interlaced:[%s])",UT_Control_GetMapString(dsVideoFrameRateMappingTable, setResolution.frameRate),\
-                         UT_Control_GetMapString(boolMappingTable, setResolution.interlaced));
+                         UT_Control_GetMapString(dsVideoScanModeMappingTable, interlaced));
     status = dsSetResolution(gHandle, &setResolution);
     UT_LOG_INFO("Result dsSetResolution(IN:Handle:[0x%0X],In:dsVideoPortResolution_t(dsVideoResolution_t:[%s]) ", gHandle,\
                     UT_Control_GetMapString(dsVideoResolutionMappingTable, setResolution.pixelResolution));
     UT_LOG_INFO("dsVideoAspectRatio_t:[%s],dsVideoStereoScopicMode_t:[%s])",UT_Control_GetMapString(dsVideoAspectRatioMappingTable, setResolution.aspectRatio),\
                          UT_Control_GetMapString(dsVideoStereoScopicModeMappingTable, setResolution.stereoScopicMode));
     UT_LOG_INFO("dsVideoFrameRate_t:[%s],interlaced:[%s]),dsError_t=[%s])",UT_Control_GetMapString(dsVideoFrameRateMappingTable, setResolution.frameRate),\
-                         UT_Control_GetMapString(boolMappingTable, setResolution.interlaced),\
+                         UT_Control_GetMapString(dsVideoScanModeMappingTable, interlaced),\
                          UT_Control_GetMapString(dsErrorMappingTable, status));
     DS_ASSERT(status == dsERR_NONE);
 


### PR DESCRIPTION
test_l3_dsVideoPort.c: The dsVideoScanMode_t enumeration represents interlaced as 0 and progressive as 1.
Assigning setResolution.interlaced = choice causes a logic inversion.
Modified the assignment to map the enumeration to the Boolean correctly (interlaced should map to true):

setResolution.interlaced = (choice == dsVIDEO_SCANMODE_INTERLACED);