### PR TITLE
gh #369 dsAudio L3 segmentation fault in MS12AudioProfile

### DIFF
--- a/src/test_l3_dsAudio.c
+++ b/src/test_l3_dsAudio.c
@@ -1895,12 +1895,12 @@ void test_l3_dsAudio_ms12Profile(void)
     }
 
     UT_LOG_INFO("Calling dsSetMS12AudioProfile(IN:handle:[0x%0X], IN:profile:[%s])",
-                 handle, profileList[choice-1]);
+                 handle, profileList[choice]);
 
     ret = dsSetMS12AudioProfile(handle, profileList[choice]);
 
     UT_LOG_INFO("Result dsSetMS12AudioProfile(IN:handle:[0x%0X], IN:profile:[%s]) dsError_t:[%s]",
-                handle, profileList[choice-1],
+                handle, profileList[choice],
                 UT_Control_GetMapString(dsError_mapTable, ret));
 
     DS_ASSERT(ret == dsERR_NONE);


### PR DESCRIPTION
Segmentation fault observed while running dsAudio_test26_MS12AudioProfiles.pyL3 test case for dsAudio
UT_LOG_INFO("Result dsSetMS12AudioProfile(IN:handle:[0x%0X], IN:profile:[%s]) dsError_t:[%s]",
                handle, profileList[choice-1],
                UT_Control_GetMapString(dsError_mapTable, ret)); 
instead of profileList[choice-1] , changed to profileList[choice].