### PR TITLE
gh #386 Update the profile yaml with supported HDR modes

### DIFF
--- a/profiles/source/Source_4K_VideoPort.yaml
+++ b/profiles/source/Source_4K_VideoPort.yaml
@@ -261,7 +261,7 @@ dsVideoPort:
             #dsHDRSTANDARD_SDR                = 0x20,  ///< Video Format SDR
             #dsHDRSTANDARD_Invalid            = 0x80   ///< When invalid value observed
             # HDR Capabilities:
-            hdr_capabilities: 0x37 # OR-ed value of SDR | HDR10 | HDR10PLUS | DolbyVision | HLG
+            hdr_capabilities: 0x25 # OR-ed value of SDR | HDR10 | DolbyVision
 
             # HDCP Protocol Version:
             #dsHDCP_VERSION_1X                = 00x0,  ///< HDCP Protocol version 1.x


### PR DESCRIPTION
Test Case (L3) : dsVideoPort_test6_VerifyVideoContentFormats

As per the issue https://ccp.sys.comcast.net/browse/RDKEVD-491 , for setForceHDRMode HDR modes like HDR10+, Technicolor Prime, HLG are not handled and currently we can force DolbyVision, HDR10, SDR formats using this API.

Update the profile yaml with supported HDR modes.