### PR TITLE
gh#424 replace dsAVICONTENT_TYPE_INVALID with dsAVICONTENT_TYPE_NOT_SIGNALLED in HDMI Input test

### DIFF
--- a/host/tests/L3_TestCases/dsHdmiIn/dsHdmiIn_test07_AVIChangeCallback_Verify.py
+++ b/host/tests/L3_TestCases/dsHdmiIn/dsHdmiIn_test07_AVIChangeCallback_Verify.py
@@ -107,7 +107,7 @@ class dsHdmiIn_test07_AVIChangeCallback_Verify(dsHdmiInHelperClass):
             #get the list avi content type list
             aviContentTypeList = self.testdsHdmiIn.getAviContentTypeList()
             for aviContentType in aviContentTypeList:
-                if aviContentType not in ["dsAVICONTENT_TYPE_INVALID", "dsAVICONTENT_TYPE_MAX"]:
+                if aviContentType not in ["dsAVICONTENT_TYPE_NOT_SIGNALLED", "dsAVICONTENT_TYPE_MAX"]:
                     self.CheckDeviceStatus(True, port, True, aviContentType)
                     time.sleep(5)
                     aviStatus = self.testdsHdmiIn.getAVIContentCallbackStatus()

--- a/host/tests/L3_TestCases/dsHdmiIn/dsHdmiIn_test07_AVIChangeCallback_Verify.py
+++ b/host/tests/L3_TestCases/dsHdmiIn/dsHdmiIn_test07_AVIChangeCallback_Verify.py
@@ -68,7 +68,7 @@ class dsHdmiIn_test07_AVIChangeCallback_Verify(dsHdmiInHelperClass):
         if manual == True and avi_input != True:
             self.testUserResponse.getUserYN(f'Please connect the {port_type} and press Enter:')
             time.sleep(3)
-            return self.testUserResponse.getUserYN(f'Is HdmiIn device connected and Displayed is ON {port_type} press Y/N:')
+            return True
         elif manual == True and avi_input == True:
             return self.testUserResponse.getUserYN(f'Change the AVI Content to {avi_content} on device connected to {port_type} and press Enter:')
         else :
@@ -90,7 +90,7 @@ class dsHdmiIn_test07_AVIChangeCallback_Verify(dsHdmiInHelperClass):
 
         # Initialize the dsHdmiIn module
         self.testdsHdmiIn.initialise()
-        result = False
+        result = True
 
         # Loop through the supported HdmiIn ports
         for port in self.testdsHdmiIn.getSupportedPorts():
@@ -99,18 +99,24 @@ class dsHdmiIn_test07_AVIChangeCallback_Verify(dsHdmiInHelperClass):
 
             # Check the HdmiIn device is active
             status = self.CheckDeviceStatus(True, port, False)
-            if not status:
-                self.testdsHdmiIn.selectHDMIInPort(port, audMix=0, videoPlane=0, topmost=1)
-                time.sleep(5)
-                self.log.step(f'Port Selected {port}')
+
+            self.testdsHdmiIn.selectHDMIInPort(port, audMix=0, videoPlane=0, topmost=1)
+            time.sleep(5)
+            self.log.step(f'Port Selected {port}')
 
             #get the list avi content type list
             aviContentTypeList = self.testdsHdmiIn.getAviContentTypeList()
+            aviContentTypeList.append(aviContentTypeList[0])
+            skip_check = True
             for aviContentType in aviContentTypeList:
                 if aviContentType not in ["dsAVICONTENT_TYPE_NOT_SIGNALLED", "dsAVICONTENT_TYPE_MAX"]:
+
                     self.CheckDeviceStatus(True, port, True, aviContentType)
-                    time.sleep(5)
+                    time.sleep(1)
                     aviStatus = self.testdsHdmiIn.getAVIContentCallbackStatus()
+                    if skip_check:
+                        skip_check = False
+                        continue
                     if aviStatus != None and aviStatus[0] == port:
                         self.log.stepResult(True,f'AVI content type:{aviStatus[1]} on port:{aviStatus[0]} found')
                         self.log.step(f'Verify content type')

--- a/host/tests/dsClasses/dsHdmiIn.py
+++ b/host/tests/dsClasses/dsHdmiIn.py
@@ -454,12 +454,11 @@ class dsHdmiInClass():
             None: If no matching connection status is found.
         """
         result = self.testSession.read_until("Received AviContentType change callback port:")
-        avipattern = r"Received AviContentType change callback port:\s*\[(.*?)\].*?avi_content_type:\s*\[(.*?)\]"
-        match = re.search(avipattern, result)
+        avipattern = r'Received AviContentType change callback port:\[(.*?)\], avi_content_type:\[(.*?)\]'
+        match = re.findall(avipattern, result)
 
         if match:
-            porttype = match.group(1)
-            avi_content_type = match.group(2)
+            porttype, avi_content_type = match[-1]
             return porttype, avi_content_type
 
         return None

--- a/host/tests/dsClasses/dsHdmiIn.py
+++ b/host/tests/dsClasses/dsHdmiIn.py
@@ -83,12 +83,12 @@ class hdmiVideoFrameRate(Enum):
       dsVIDEO_FRAMERATE_MAX = 9      # Out of range
 
 class hdmiInAviContentType(Enum):
-      dsAVICONTENT_TYPE_GRAPHICS = 0   #/*!< Content type Graphics. */
-      dsAVICONTENT_TYPE_PHOTO = 1      #/*!< Content type Photo */
-      dsAVICONTENT_TYPE_CINEMA = 2     #/*!< Content type Cinema */
-      dsAVICONTENT_TYPE_GAME = 3       #/*!< Content type Game */
-      dsAVICONTENT_TYPE_INVALID = 4    #/*!< Content type Invalid */
-      dsAVICONTENT_TYPE_MAX = 5        #/*!< Out of range */
+      dsAVICONTENT_TYPE_GRAPHICS = 0      #/*!< Content type Graphics. */
+      dsAVICONTENT_TYPE_PHOTO = 1         #/*!< Content type Photo */
+      dsAVICONTENT_TYPE_CINEMA = 2        #/*!< Content type Cinema */
+      dsAVICONTENT_TYPE_GAME = 3          #/*!< Content type Game */
+      dsAVICONTENT_TYPE_NOT_SIGNALLED = 4 #/*!< Content type Invalid */
+      dsAVICONTENT_TYPE_MAX = 5           #/*!< Out of range */
 
 class hdmiInZoomMode(Enum):
       dsVIDEO_ZOOM_NONE = 0


### PR DESCRIPTION
Replaced the deprecated enum dsAVICONTENT_TYPE_INVALID with dsAVICONTENT_TYPE_NOT_SIGNALLED as per the latest interface update