### PR TITLE
gh #447 videoport l1 l2 tvapi revisit

### DIFF
--- a/docs/pages/dsVideoPort/ds-video-port_L2_Low-Level_TestSpecification.md
+++ b/docs/pages/dsVideoPort/ds-video-port_L2_Low-Level_TestSpecification.md
@@ -218,7 +218,7 @@ graph TB
 |Title|Details|
 |-----|-------|
 |Function Name|`test_l2_dsVideoPort_VerifySupportedTvResolutions`|
-|Description|Get the handle for supported video port from configuration file(`dsVideoPort/Number_of_ports`), check the status of each supported video port type `dsVideoPort/Ports/[port no]/Typeid`.Gets the supported port Resolutions of TV and verify with the configuration file `dsVideoPort/Ports/[port no]/Supported_tv_resolutions_capabilities`|
+|Description|Get the handle for supported video port from configuration file(`dsVideoPort/Number_of_ports`), check the status of each supported video port type `dsVideoPort/Ports/[port no]/Typeid`.Gets the supported port Resolutions of TV and verify with the configuration file `dsVideoPort/Ports/[port no]/Supported_tv_resolutions_capabilities` or default value based on the dsIsDisplayConnected status|
 |Test Group|02|
 |Test Case ID|005|
 |Priority|High|
@@ -239,7 +239,7 @@ If user chose to run the test in interactive mode, then the test case has to be 
 |01|Initialize the video port using `dsVideoPortInit`|None|`dsERR_NONE`|Should be successful|
 |02|Get the video port handle for supported type of video port using `dsGetVideoPort` Loop through each video port and get the handle using `dsGetVideoPort`| type = `dsVideoPort/Ports/[port no]/Typeid` index = `dsVideoPort/Ports/[port no]/Index`.|`dsERR_NONE`|Should be successful|
 |03|Get the supported TV resolutions using `dsSupportedTvResolutions` with the obtained handle|handle = obtained from previous step|`dsERR_NONE`|Should be successful|
-|04|Verify the obtained resolutions with the expected resolutions from the configuration file|resolutions = value in `dsVideoPort/Ports/[port no]/Supported_tv_resolutions_capabilities`|`dsERR_NONE`|Should be successful|
+|04|Verify the obtained resolutions with the expected resolutions from the configuration file or default value based on the dsIsDisplayConnected status|resolutions = value in `dsVideoPort/Ports/[port no]/Supported_tv_resolutions_capabilities` or default value |`dsERR_NONE`|Should be successful|
 |05|Terminate the video port using `dsVideoPortTerm`|None|`dsERR_NONE`|Should be successful|
 
 ```mermaid
@@ -261,7 +261,7 @@ graph TB
 |Title|Details|
 |-----|-------|
 |Function Name|`test_l2_dsVideoPort_GetHDRCapabilities`|
-|Description|Get the handle for supported video port from configuration file(`dsVideoPort/Number_of_ports`), check the status of each supported video port type `dsVideoPort/Ports/[port no]/Typeid`.Get the each supported port HDR capabilities & verify with the configuration file `dsVideoPort/Ports/[port no]/hdr_capabilities`|
+|Description|Get the handle for supported video port from configuration file(`dsVideoPort/Number_of_ports`), check the status of each supported video port type `dsVideoPort/Ports/[port no]/Typeid`.Get the each supported port HDR capabilities & verify with the configuration file `dsVideoPort/Ports/[port no]/hdr_capabilities` or default value based on the dsIsDisplayConnected status|
 |Test Group|02|
 |Test Case ID|006|
 |Priority|High|
@@ -282,7 +282,7 @@ If user chose to run the test in interactive mode, then the test case has to be 
 |01|Initialize the video port using `dsVideoPortInit`|None|`dsERR_NONE`|Should be successful|
 |02|Get the video port handle for supported type of video port using dsGetVideoPort Loop through each video port and get the handle using `dsGetVideoPort`| type = `dsVideoPort/Ports/[port no]/Typeid` index = `dsVideoPort/Ports/[port no]/Index`.|`dsERR_NONE`|Should be successful|
 |03|Get the HDR capabilities of the TV using `dsGetTVHDRCapabilities` with the obtained handle|handle = obtained from previous step|`dsERR_NONE`|Should be successful|
-|04|Verify the obtained capabilities with the configuration file `dsVideoPort/Ports/[port no]/hdr_capabilities`|Values should match|capabilities = value in `dsVideoPort/Ports/[port no]/hdr_capabilities`|Should be successful|
+|04|Verify the obtained capabilities with the configuration file `dsVideoPort/Ports/[port no]/hdr_capabilities` or default value based on the dsIsDisplayConnected status|Values should match|capabilities = value in `dsVideoPort/Ports/[port no]/hdr_capabilities` or default value|Should be successful|
 |05|Terminate the video port using `dsVideoPortTerm`|None|`dsERR_NONE`|Should be successful|
 
 ```mermaid
@@ -303,7 +303,7 @@ graph TB
 |Title|Details|
 |-----|-------|
 |Function Name|`test_l2_dsVideoPort_GetHDCPStatus`|
-|Description|Get the handle for supported video port from configuration file(`dsVideoPort/Number_of_ports`), check the status of each supported video port type `dsVideoPort/Ports/[port no]/Typeid`.Check the `HDCP` status of each supported port and verify if `dsHDCP_STATUS_AUTHENTICATED` is returned for sinks and `dsHDCP_STATUS_UNPOWERED`/`dsHDCP_STATUS_PORTDISABLED` is returned for sources.|
+|Description|Get the handle for supported video port from configuration file(`dsVideoPort/Number_of_ports`), check the status of each supported video port type `dsVideoPort/Ports/[port no]/Typeid`.Check the `HDCP` status of each supported port and verify if `dsHDCP_STATUS_AUTHENTICATED` is returned when display is connected and `dsHDCP_STATUS_UNPOWERED`/`dsHDCP_STATUS_PORTDISABLED` is returned when display not connected|
 |Test Group|02|
 |Test Case ID|007|
 |Priority|High|
@@ -324,7 +324,7 @@ If user chose to run the test in interactive mode, then the test case has to be 
 |01|Initialize the video port using `dsVideoPortInit`|None|`dsERR_NONE`|Should be successful|
 |02|Get the video port handle for supported type of video port using `dsGetVideoPort` Loop through each video port and get the handle using `dsGetVideoPort`| type = `dsVideoPort/Ports/[port no]/Typeid` index = `dsVideoPort/Ports/[port no]/Index`.|`dsERR_NONE`|Should be successful|
 |03|Get the `HDCP` status for each handle using `dsGetHDCPStatus`|handle = obtained from dsGetVideoPort()|`dsERR_NONE`|Should be successful|
-|04|Check if the `HDCP` status is authenticated|status = obtained from `dsGetHDCPStatus`|`dsHDCP_STATUS_AUTHENTICATED`|Should be successful|
+|04|Check if the `HDCP` status for source and sink devices based on the isDisplayConnected status |status = obtained from `dsGetHDCPStatus`|`dsHDCP_STATUS_AUTHENTICATED` or `dsHDCP_STATUS_UNPOWERED`/`dsHDCP_STATUS_PORTDISABLED`|Should be successful|
 |05|Terminate the video port using `dsVideoPortTerm`|None|`dsERR_NONE`|Should be successful|
 
 ```mermaid
@@ -472,7 +472,7 @@ E -->|dsERR_NONE|E1[Test case fail]
 |Title|Details|
 |-----|-------|
 |Function Name|`test_l2_dsVideoPort_CheckColorDepthCapabilities_source`|
-|Description|Check each port Color Depth Capabilities and compare with the configuration file.|
+|Description|Check each port Color Depth Capabilities and compare with the configuration file or default value.|
 |Test Group|02|
 |Test Case ID|011|
 |Priority|High|
@@ -514,7 +514,7 @@ graph TB
 |Title|Details|
 |-----|-------|
 |Function Name|`test_l2_dsVideoPort_GetColorDepth`|
-|Description|Get each port Color Depth and verify with the configuration file.|
+|Description|Get each port Color Depth and verify with the configuration file or default value.|
 |Test Group|02|
 |Test Case ID|012|
 |Priority|High|
@@ -535,7 +535,7 @@ If user chose to run the test in interactive mode, then the test case has to be 
 |01|Initialize the video port using `dsVideoPortInit`|None|`dsERR_NONE`|Should be successful|
 |02|Get the video port handle using `dsGetVideoPort` with type=`dsVIDEOPORT_TYPE_INTERNAL` and index=0|type=`dsVIDEOPORT_TYPE_INTERNAL`, index=0|`dsERR_NONE`|Should be successful|
 |03|Get the color depth using `dsGetColorDepth` with the obtained handle|handle=obtained handle|`dsERR_NONE`|Should be successful|
-|04|Verify the obtained color depth with the value from the configuration file|color_depth=value in `dsVideoPort/Ports/[port no]/Supported_color_depth_capabilities`|Should be equal|Should be successful|
+|04|Verify the obtained color depth with the value from the configuration file or default value based on the isDisplayConnected status |color_depth=value in `dsVideoPort/color_depth` or default value|Should be equal|Should be successful|
 |05|Terminate the video port using `dsVideoPortTerm`|None|`dsERR_NONE`|Should be successful|
 
 ```mermaid

--- a/docs/pages/dsVideoPort/ds-video-port_L2_Low-Level_TestSpecification.md
+++ b/docs/pages/dsVideoPort/ds-video-port_L2_Low-Level_TestSpecification.md
@@ -472,7 +472,7 @@ E -->|dsERR_NONE|E1[Test case fail]
 |Title|Details|
 |-----|-------|
 |Function Name|`test_l2_dsVideoPort_CheckColorDepthCapabilities_source`|
-|Description|Check each port Color Depth Capabilities and compare with the configuration file or default value.|
+|Description|Check each port Color Depth Capabilities and compare with the configuration file.|
 |Test Group|02|
 |Test Case ID|011|
 |Priority|High|

--- a/src/test_dsVideoPort_parse_configuration.h
+++ b/src/test_dsVideoPort_parse_configuration.h
@@ -78,6 +78,7 @@
 #define DS_VIDEO_PORT_RESOLUTION_NUM_MAX      32
 
 #define DS_VIDEO_PORT_MODULE_NAME             "dsVideoPort"
+#define DS_VIDEO_PORT_DEFAULT_COLORDEPTH      8
 
 /* Video Port configuration */
 typedef struct 

--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -2029,9 +2029,13 @@ void test_l1_dsVideoPort_positive_dsGetHDCPStatus(void) {
                 UT_ASSERT_EQUAL(status, dsERR_OPERATION_NOT_SUPPORTED);
             } else {
                 UT_ASSERT_EQUAL(status, dsERR_NONE);
-                dsHdcpStatus_t hdcpStatus2 = dsHDCP_STATUS_UNPOWERED;
-                status = dsGetHDCPStatus(handle, &(hdcpStatus2));
-                UT_ASSERT_EQUAL(hdcpStatus1, hdcpStatus2);
+                bool isConnected = false;
+                status = dsIsDisplayConnected(handle, &isConnected);
+                if (!isConnected) {
+                    UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_PORTDISABLED)
+                } else {
+                    UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_AUTHENTICATED)
+                }
             }
         } else if(gSourceType == 0) {
             UT_ASSERT_EQUAL(status, dsERR_NONE);

--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -72,6 +72,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "dsVideoPort.h"
+#include "dsDisplay.h"
 #include "test_parse_configuration.h"
 
 #include <ut.h>
@@ -2021,6 +2022,14 @@ void test_l1_dsVideoPort_positive_dsGetHDCPStatus(void) {
         UT_ASSERT_PTR_NOT_NULL(handle);
         if (handle == 0)
             break;
+        status = dsDisplayInit();
+        bool isConnected = false;
+        status = dsIsDisplayConnected(handle, &isConnected);
+        if (isConnected){
+            char hdcpKey[HDCP_KEY_MAX_SIZE] = "ADEF";
+            int keySize = HDCP_KEY_MAX_SIZE;
+            status = dsEnableHDCP(handle, true, hdcpKey, keySize);
+        }
         // Step 03: Retrieve the HDCP status
         status = dsGetHDCPStatus(handle, &(hdcpStatus1));
         // Step 04: Compare the value with values of profile file
@@ -2029,8 +2038,6 @@ void test_l1_dsVideoPort_positive_dsGetHDCPStatus(void) {
                 UT_ASSERT_EQUAL(status, dsERR_OPERATION_NOT_SUPPORTED);
             } else {
                 UT_ASSERT_EQUAL(status, dsERR_NONE);
-                bool isConnected = false;
-                status = dsIsDisplayConnected(handle, &isConnected);
                 if (!isConnected) {
                     UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_PORTDISABLED)
                 } else {
@@ -2041,6 +2048,7 @@ void test_l1_dsVideoPort_positive_dsGetHDCPStatus(void) {
             UT_ASSERT_EQUAL(status, dsERR_NONE);
             UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_AUTHENTICATED);
         }
+        status = dsDisplayTerm();
     }
 
     // Step 05: Terminate the video port system
@@ -2554,6 +2562,7 @@ void test_l1_dsVideoPort_positive_dsGetTVHDRCapabilities(void) {
         status = dsGetTVHDRCapabilities(handle, &capabilities1);
         UT_ASSERT_EQUAL(status, dsERR_NONE);
         // Step 04: Compare the value with profile file values
+        status = dsDisplayInit();
         bool isConnected = false;
         status = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
@@ -2562,6 +2571,7 @@ void test_l1_dsVideoPort_positive_dsGetTVHDRCapabilities(void) {
         else {
             UT_ASSERT_EQUAL(capabilities1, gDSVideoPortConfiguration[i].hdr_capabilities);
         }
+        status = dsDisplayTerm();
     }
 
     // Step 05: Terminate the video port system
@@ -2689,6 +2699,7 @@ void test_l1_dsVideoPort_positive_dsSupportedTvResolutions(void) {
         status = dsSupportedTvResolutions(handle, &resolutions1);
         UT_ASSERT_EQUAL(status, dsERR_NONE);
         // Step 04: Compare the value with value from profile file
+        status = dsDisplayInit();
         bool isConnected = false;
         status = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
@@ -2697,6 +2708,7 @@ void test_l1_dsVideoPort_positive_dsSupportedTvResolutions(void) {
         else {
             UT_ASSERT_EQUAL(resolutions1, gDSVideoPortConfiguration[i].Supported_tv_resolutions_capabilities);
         }
+        status = dsDisplayTerm();
     }
 
     // Step 05: Terminate the video port system
@@ -3336,6 +3348,7 @@ void test_l1_dsVideoPort_positive_dsGetColorDepth(void) {
         status = dsGetColorDepth(handle, &colorDepth1);
         UT_ASSERT_EQUAL(status, dsERR_NONE);
         // Step 04: Compare the value with values from profile file
+        status = dsDisplayInit();
         bool isConnected = false;
         status = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
@@ -3344,6 +3357,7 @@ void test_l1_dsVideoPort_positive_dsGetColorDepth(void) {
         else {
             UT_ASSERT_EQUAL(colorDepth1, gDSvideoPort_color_depth);
         }
+        status = dsDisplayTerm();
     }
 
     // Step 05: Terminate the video port system

--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -2039,7 +2039,7 @@ void test_l1_dsVideoPort_positive_dsGetHDCPStatus(void) {
             } else {
                 UT_ASSERT_EQUAL(status, dsERR_NONE);
                 if (!isConnected) {
-                    UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_PORTDISABLED)
+                    UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_UNPOWERED)
                 } else {
                     UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_AUTHENTICATED)
                 }

--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -2703,7 +2703,7 @@ void test_l1_dsVideoPort_positive_dsSupportedTvResolutions(void) {
         bool isConnected = false;
         status = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
-            UT_ASSERT_EQUAL(resolutions1, 0);
+            UT_ASSERT_EQUAL(resolutions1, (int)dsTV_RESOLUTION_480i);
         }
         else {
             UT_ASSERT_EQUAL(resolutions1, gDSVideoPortConfiguration[i].Supported_tv_resolutions_capabilities);
@@ -2828,6 +2828,9 @@ void test_l1_dsVideoPort_positive_dsSetForceDisable4KSupport(void) {
     for (int i = 0; i < gDSvideoPort_NumberOfPorts; i++) {
         status = dsGetVideoPort(gDSVideoPortConfiguration[i].typeid, gDSVideoPortConfiguration[i].index, &(handle));
         UT_ASSERT_EQUAL(status, dsERR_NONE);
+        UT_ASSERT_PTR_NOT_NULL(handle);
+        if (handle == 0)
+            break;
         // Step 03: Set force disable 4K support
         status = dsSetForceDisable4KSupport(handle, disable4K);
         UT_ASSERT_EQUAL(status, dsERR_OPERATION_NOT_SUPPORTED);

--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -1998,7 +1998,7 @@ void test_l1_dsVideoPort_negative_dsRegisterHdcpStatusCallback(void) {
  * |01|Call dsVideoPortInit() - Initialize video port system | | dsERR_NONE | Initialization must be successful |
  * |02|Call dsGetVideoPort() - Get the video port handle for valid video port type and valid index | type, index = [Loop through kPorts] , handle = [valid handle] | dsERR_NONE | Valid port handle must be returned |
  * |03|Call dsGetHDCPStatus() by looping through the acquired port handles and valid pointer to retrieve HDCP status | handle  = [valid handles] status = [valid pointer] | dsERR_NONE | The HDCP status must be successfully fetched and stored in the given pointer or indicate that the operation isn't supported|
- * |04|Compare the values with the HDCP status for sink and source devices respectively | | dsERR_NONE | The values must be equal |
+ * |04|Compare the values with the HDCP status for sink and source devices respectively based on the dsIsDisplayConnected status | | dsERR_NONE | The values must be equal |
  * |05|Call dsVideoPortTerm() - Terminate the video port system | | dsERR_NONE | Termination must be successful |
  * 
  */
@@ -2526,7 +2526,7 @@ void test_l1_dsVideoPort_negative_dsGetHDCPCurrentProtocol(void) {
  * |01|Call dsVideoPortInit() - Initialize video ports of a system | |dsERR_NONE| Initialization must be successful |
  * |02|Call dsGetVideoPort() - Get the port handle for all supported video ports on the platform  |type ,  index = [ Loop through kPorts ] |dsERR_NONE | Valid port handle must be returned for all supported video ports|
  * |03|Call dsGetTVHDRCapabilities() by looping through the acquired port handles and valid pointer to retrieve the HDR capabilities of a video port | handle  = [loop through valid handles] , capabilities = [valid pointer] |dsERR_NONE|The HDR capabilities must be successfully fetched and stored in the given pointer|
- * |04|Compare the values with values from profile file and make sure they are equal | | dsERR_NONE | The values must be equal |
+ * |04|Compare the values with values from profile file or default value based on the dsIsDisplayConnected status and make sure they are equal | | dsERR_NONE | The values must be equal |
  * |05|Call dsVideoPortTerm() - Terminate the video port system | | dsERR_NONE | Termination must be successful |
  * 
  */
@@ -2661,7 +2661,7 @@ void test_l1_dsVideoPort_negative_dsGetTVHDRCapabilities(void) {
  * |01|Call dsVideoPortInit() - Initialize video ports of a system | |dsERR_NONE| Initialization must be successful |
  * |02|Call dsGetVideoPort() - Get the port handle for all supported video ports on the platform  |type ,  index = [ Loop through kPorts ] |dsERR_NONE | Valid port handle must be returned for all supported video ports|
  * |03|Call dsSupportedTvResolutions() by looping through the acquired port handles and valid pointer to retrieve the resolutions of a video port |handle  = [loop through valid handles] , resolutions = [valid pointer] |dsERR_NONE|Resolutions must be set successfully|
- * |05|Compare the values with values from profile file and make sure they are equal | | dsERR_NONE | The values must be equal |
+ * |05|Compare the values with values from profile file or default value based on the dsIsDisplayConnected status and make sure they are equal | | dsERR_NONE | The values must be equal |
  * |06|Call dsVideoPortTerm() - Terminate the video ports of a system| |dsERR_NONE|Termination must be successful|
  * 
  */
@@ -3308,7 +3308,7 @@ void test_l1_dsVideoPort_negative_dsGetMatrixCoefficients(void) {
  * |01|Call dsVideoPortInit() - Initialize video port system | | dsERR_NONE | Initialization must be successful |
  * |02|Call dsGetVideoPort() - Get the video port handle for valid video port type and valid index | type, index = [Loop through kPorts] , handle = [valid handle] | dsERR_NONE | Valid port handle must be returned |
  * |03|Call dsGetColorDepth() by looping through the acquired port handles and valid pointer to retrieve the current color depth  | handle  = [loop through valid handles] , color_depth = [valid pointer] | dsERR_NONE | must return a valid color depth value of the specified video port|
- * |04|Compare the values with values from profile file and make sure they are equal | | dsERR_NONE | The values must be equal |
+ * |04|Compare the values with values from profile file or default value based on the dsIsDisplayConnected status and make sure they are equal | | dsERR_NONE | The values must be equal |
  * |06|Call dsVideoPortTerm() - Terminate the video port system | | dsERR_NONE | Termination must be successful |
  * 
  */

--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -2024,15 +2024,17 @@ void test_l1_dsVideoPort_positive_dsGetHDCPStatus(void) {
         // Step 03: Retrieve the HDCP status
         status = dsGetHDCPStatus(handle, &(hdcpStatus1));
         // Step 04: Compare the value with values of profile file
-        if (gSourceType == 0) {
+        if (gSourceType == 1) {
             if (gDSVideoPortConfiguration[i].hdcp_supported == false) {
                 UT_ASSERT_EQUAL(status, dsERR_OPERATION_NOT_SUPPORTED);
             } else {
                 UT_ASSERT_EQUAL(status, dsERR_NONE);
-                UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_AUTHENTICATED);
+                dsHdcpStatus_t hdcpStatus2;
+                status = dsGetHDCPStatus(handle, &(hdcpStatus2));
+                UT_ASSERT_EQUAL(hdcpStatus1, hdcpStatus2);
             }
-        } else if(gSourceType == 1) {
-            UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_PORTDISABLED);
+        } else if(gSourceType == 0) {
+            UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_AUTHENTICATED);
         }
     }
 
@@ -2547,7 +2549,14 @@ void test_l1_dsVideoPort_positive_dsGetTVHDRCapabilities(void) {
         status = dsGetTVHDRCapabilities(handle, &capabilities1);
         UT_ASSERT_EQUAL(status, dsERR_NONE);
         // Step 04: Compare the value with profile file values
-        UT_ASSERT_EQUAL(capabilities1, gDSVideoPortConfiguration[i].hdr_capabilities);
+        bool isConnected = false;
+        status = dsIsDisplayConnected(handle, &isConnected);
+        if(!isConnected) {
+            UT_ASSERT_EQUAL(capabilities1, dsHDRSTANDARD_SDR);
+        }
+        else {
+            UT_ASSERT_EQUAL(capabilities1, gDSVideoPortConfiguration[i].hdr_capabilities);
+        }
     }
 
     // Step 05: Terminate the video port system
@@ -2675,7 +2684,14 @@ void test_l1_dsVideoPort_positive_dsSupportedTvResolutions(void) {
         status = dsSupportedTvResolutions(handle, &resolutions1);
         UT_ASSERT_EQUAL(status, dsERR_NONE);
         // Step 04: Compare the value with value from profile file
-        UT_ASSERT_EQUAL(resolutions1, gDSVideoPortConfiguration[i].Supported_tv_resolutions_capabilities);
+        bool isConnected = false;
+        status = dsIsDisplayConnected(handle, &isConnected);
+        if(!isConnected) {
+            UT_ASSERT_EQUAL(resolutions1, 0);
+        }
+        else {
+            UT_ASSERT_EQUAL(resolutions1, gDSVideoPortConfiguration[i].Supported_tv_resolutions_capabilities);
+        }
     }
 
     // Step 05: Terminate the video port system
@@ -2795,9 +2811,6 @@ void test_l1_dsVideoPort_positive_dsSetForceDisable4KSupport(void) {
     for (int i = 0; i < gDSvideoPort_NumberOfPorts; i++) {
         status = dsGetVideoPort(gDSVideoPortConfiguration[i].typeid, gDSVideoPortConfiguration[i].index, &(handle));
         UT_ASSERT_EQUAL(status, dsERR_NONE);
-        UT_ASSERT_PTR_NOT_NULL(handle);
-        if (handle == 0)
-            break;
         // Step 03: Set force disable 4K support
         status = dsSetForceDisable4KSupport(handle, disable4K);
         UT_ASSERT_EQUAL(status, dsERR_OPERATION_NOT_SUPPORTED);
@@ -3318,7 +3331,14 @@ void test_l1_dsVideoPort_positive_dsGetColorDepth(void) {
         status = dsGetColorDepth(handle, &colorDepth1);
         UT_ASSERT_EQUAL(status, dsERR_NONE);
         // Step 04: Compare the value with values from profile file
-        UT_ASSERT_EQUAL(colorDepth1, gDSvideoPort_color_depth);
+        bool isConnected = false;
+        status = dsIsDisplayConnected(handle, &isConnected);
+        if(!isConnected) {
+            UT_ASSERT_EQUAL(colorDepth1, 8);
+        }
+        else {
+            UT_ASSERT_EQUAL(colorDepth1, gDSvideoPort_color_depth);
+        }
     }
 
     // Step 05: Terminate the video port system

--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -2703,7 +2703,7 @@ void test_l1_dsVideoPort_positive_dsSupportedTvResolutions(void) {
         bool isConnected = false;
         status = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
-            UT_ASSERT_EQUAL(resolutions1, (int)dsTV_RESOLUTION_480i);
+            UT_ASSERT_EQUAL(resolutions1, (int)dsTV_RESOLUTION_480p);
         }
         else {
             UT_ASSERT_EQUAL(resolutions1, gDSVideoPortConfiguration[i].Supported_tv_resolutions_capabilities);
@@ -3355,7 +3355,7 @@ void test_l1_dsVideoPort_positive_dsGetColorDepth(void) {
         bool isConnected = false;
         status = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
-            UT_ASSERT_EQUAL(colorDepth1, 8);
+            UT_ASSERT_EQUAL(colorDepth1, DS_VIDEO_PORT_DEFAULT_COLORDEPTH);
         }
         else {
             UT_ASSERT_EQUAL(colorDepth1, gDSvideoPort_color_depth);

--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -2015,7 +2015,7 @@ void test_l1_dsVideoPort_positive_dsGetHDCPStatus(void) {
 
     // Step 02: Get the video port handle
     for (int i = 0; i < gDSvideoPort_NumberOfPorts; i++) {
-        dsHdcpStatus_t hdcpStatus1;
+        dsHdcpStatus_t hdcpStatus1 = dsHDCP_STATUS_UNPOWERED;
         status = dsGetVideoPort(gDSVideoPortConfiguration[i].typeid, gDSVideoPortConfiguration[i].index, &(handle));
         UT_ASSERT_EQUAL(status, dsERR_NONE);
         UT_ASSERT_PTR_NOT_NULL(handle);
@@ -2029,11 +2029,12 @@ void test_l1_dsVideoPort_positive_dsGetHDCPStatus(void) {
                 UT_ASSERT_EQUAL(status, dsERR_OPERATION_NOT_SUPPORTED);
             } else {
                 UT_ASSERT_EQUAL(status, dsERR_NONE);
-                dsHdcpStatus_t hdcpStatus2;
+                dsHdcpStatus_t hdcpStatus2 = dsHDCP_STATUS_UNPOWERED;
                 status = dsGetHDCPStatus(handle, &(hdcpStatus2));
                 UT_ASSERT_EQUAL(hdcpStatus1, hdcpStatus2);
             }
         } else if(gSourceType == 0) {
+            UT_ASSERT_EQUAL(status, dsERR_NONE);
             UT_ASSERT_EQUAL(hdcpStatus1, dsHDCP_STATUS_AUTHENTICATED);
         }
     }

--- a/src/test_l2_dsVideoPort.c
+++ b/src/test_l2_dsVideoPort.c
@@ -578,6 +578,8 @@ void test_l2_dsVideoPort_GetHDCPStatus(void)
         bool isConnected = false;
         ret = dsIsDisplayConnected(handle, &isConnected);
         if (isConnected){
+            // For vendor image enableHDCP has to be done from code
+            // enableHDCP only if displayconnected is true
             char hdcpKey[HDCP_KEY_MAX_SIZE] = "ADEF";
             int keySize = HDCP_KEY_MAX_SIZE;
             ret = dsEnableHDCP(handle, true, hdcpKey, keySize);

--- a/src/test_l2_dsVideoPort.c
+++ b/src/test_l2_dsVideoPort.c
@@ -443,10 +443,12 @@ void test_l2_dsVideoPort_VerifySupportedTvResolutions(void)
         ret = dsSupportedTvResolutions(handle, &resolutions);
         UT_LOG_DEBUG("Returned status: %d, resolutions: %d", ret, resolutions);
         UT_ASSERT_EQUAL(ret, dsERR_NONE);
-        if(gSourceType == 1) {
+        bool isConnected = false;
+        ret = dsIsDisplayConnected(handle, &isConnected);
+        if(!isConnected) {
             UT_ASSERT_EQUAL(resolutions, 0);
         }
-        else if(gSourceType == 0) {
+        else {
             UT_ASSERT_EQUAL(resolutions, gDSVideoPortConfiguration[port].Supported_tv_resolutions_capabilities);
         }
     } /* for (port) */
@@ -506,11 +508,12 @@ void test_l2_dsVideoPort_GetHDRCapabilities(void)
         ret = dsGetTVHDRCapabilities(handle, &capabilities);
         UT_LOG_DEBUG("Returned status: %d, capabilities: %d", ret, capabilities);
         UT_ASSERT_EQUAL(ret, dsERR_NONE);
-
-        if(gSourceType == 1) {
+        bool isConnected = false;
+        ret = dsIsDisplayConnected(handle, &isConnected);
+        if(!isConnected) {
             UT_ASSERT_EQUAL(capabilities, dsHDRSTANDARD_SDR);
         }
-        else if(gSourceType == 0) {
+        else {
             UT_ASSERT_EQUAL(capabilities, gDSVideoPortConfiguration[port].hdr_capabilities);
         }
     } /* for (port) */
@@ -544,7 +547,7 @@ void test_l2_dsVideoPort_GetHDCPStatus(void)
 
     dsError_t ret   = dsERR_NONE;
     intptr_t handle = 0;
-    dsHdcpStatus_t status;
+    dsHdcpStatus_t status = dsHDCP_STATUS_UNPOWERED;
 
     UT_LOG_DEBUG("Invoking dsVideoPortInit()");
     ret = dsVideoPortInit();
@@ -891,7 +894,14 @@ void test_l2_dsVideoPort_GetColorDepth(void)
         UT_ASSERT_EQUAL(ret, dsERR_NONE);
         UT_LOG_DEBUG("dsGetColorDepth() returned color_depth=%u and status=%d", color_depth, ret);
 
-        UT_ASSERT_EQUAL(color_depth, gDSvideoPort_color_depth);
+        bool isConnected = false;
+        ret = dsIsDisplayConnected(handle, &isConnected);
+        if(!isConnected) {
+            UT_ASSERT_EQUAL(color_depth, 8);
+        }
+        else {
+            UT_ASSERT_EQUAL(color_depth, gDSvideoPort_color_depth);
+        }
     } /* for (port) */
 
     UT_LOG_DEBUG("Invoking dsVideoPortTerm()");

--- a/src/test_l2_dsVideoPort.c
+++ b/src/test_l2_dsVideoPort.c
@@ -74,9 +74,11 @@
 #include <ut_log.h>
 #include <ut_kvp_profile.h>
 #include <ut_kvp.h>
+#include <unistd.h>
 
 #include "test_parse_configuration.h"
 #include "dsVideoPort.h"
+#include "dsDisplay.h"
 
 static int gTestGroup = 2;
 static int gTestID = 1;
@@ -443,6 +445,7 @@ void test_l2_dsVideoPort_VerifySupportedTvResolutions(void)
         ret = dsSupportedTvResolutions(handle, &resolutions);
         UT_LOG_DEBUG("Returned status: %d, resolutions: %d", ret, resolutions);
         UT_ASSERT_EQUAL(ret, dsERR_NONE);
+        ret = dsDisplayInit();
         bool isConnected = false;
         ret = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
@@ -451,6 +454,7 @@ void test_l2_dsVideoPort_VerifySupportedTvResolutions(void)
         else {
             UT_ASSERT_EQUAL(resolutions, gDSVideoPortConfiguration[port].Supported_tv_resolutions_capabilities);
         }
+        ret = dsDisplayTerm();
     } /* for (port) */
 
     UT_LOG_DEBUG("Invoking dsVideoPortTerm");
@@ -508,6 +512,7 @@ void test_l2_dsVideoPort_GetHDRCapabilities(void)
         ret = dsGetTVHDRCapabilities(handle, &capabilities);
         UT_LOG_DEBUG("Returned status: %d, capabilities: %d", ret, capabilities);
         UT_ASSERT_EQUAL(ret, dsERR_NONE);
+        ret = dsDisplayInit();
         bool isConnected = false;
         ret = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
@@ -516,6 +521,7 @@ void test_l2_dsVideoPort_GetHDRCapabilities(void)
         else {
             UT_ASSERT_EQUAL(capabilities, gDSVideoPortConfiguration[port].hdr_capabilities);
         }
+        ret = dsDisplayTerm();
     } /* for (port) */
 
     UT_LOG_DEBUG("Invoking dsVideoPortTerm()");
@@ -568,6 +574,15 @@ void test_l2_dsVideoPort_GetHDCPStatus(void)
         if (handle == 0)
             break;
 
+        ret = dsDisplayInit();
+        bool isConnected = false;
+        ret = dsIsDisplayConnected(handle, &isConnected);
+        if (isConnected){
+            char hdcpKey[HDCP_KEY_MAX_SIZE] = "ADEF";
+            int keySize = HDCP_KEY_MAX_SIZE;
+            ret = dsEnableHDCP(handle, true, hdcpKey, keySize);
+            sleep(2);
+        }
         UT_LOG_DEBUG("Invoking dsGetHDCPStatus() with handle: %ld", handle);
         ret = dsGetHDCPStatus(handle, &status);
         if (ret != dsERR_NONE)
@@ -577,9 +592,6 @@ void test_l2_dsVideoPort_GetHDCPStatus(void)
         }
         UT_LOG_DEBUG("Return status: %d, HDCP Status: %d", ret, status);
 
-        bool isConnected = false;
-        ret = dsIsDisplayConnected(handle, &isConnected);
-        /* check for source */
         if(!isConnected) {
             UT_ASSERT_TRUE(status == dsHDCP_STATUS_UNPOWERED || status == dsHDCP_STATUS_PORTDISABLED);
             if (status != dsHDCP_STATUS_UNPOWERED || status != dsHDCP_STATUS_PORTDISABLED) {
@@ -587,12 +599,12 @@ void test_l2_dsVideoPort_GetHDCPStatus(void)
             }
         }
         else {
-            /*check for sink*/
             UT_ASSERT_EQUAL(status, dsHDCP_STATUS_AUTHENTICATED);
             if (status != dsHDCP_STATUS_AUTHENTICATED) {
                 UT_LOG_ERROR("HDCP status is not authenticated. Status: %d", status);
             }
         }
+        ret = dsDisplayTerm();
     } /* for (port) */
 
     UT_LOG_DEBUG("Invoking dsVideoPortTerm()");
@@ -896,6 +908,7 @@ void test_l2_dsVideoPort_GetColorDepth(void)
         UT_ASSERT_EQUAL(ret, dsERR_NONE);
         UT_LOG_DEBUG("dsGetColorDepth() returned color_depth=%u and status=%d", color_depth, ret);
 
+        ret = dsDisplayInit();
         bool isConnected = false;
         ret = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
@@ -904,6 +917,7 @@ void test_l2_dsVideoPort_GetColorDepth(void)
         else {
             UT_ASSERT_EQUAL(color_depth, gDSvideoPort_color_depth);
         }
+        ret = dsDisplayTerm();
     } /* for (port) */
 
     UT_LOG_DEBUG("Invoking dsVideoPortTerm()");

--- a/src/test_l2_dsVideoPort.c
+++ b/src/test_l2_dsVideoPort.c
@@ -577,14 +577,16 @@ void test_l2_dsVideoPort_GetHDCPStatus(void)
         }
         UT_LOG_DEBUG("Return status: %d, HDCP Status: %d", ret, status);
 
+        bool isConnected = false;
+        ret = dsIsDisplayConnected(handle, &isConnected);
         /* check for source */
-        if(gSourceType == 1) {
+        if(!isConnected) {
             UT_ASSERT_TRUE(status == dsHDCP_STATUS_UNPOWERED || status == dsHDCP_STATUS_PORTDISABLED);
             if (status != dsHDCP_STATUS_UNPOWERED || status != dsHDCP_STATUS_PORTDISABLED) {
                 UT_LOG_ERROR("HDCP status is not unpowered or portdisabled. Status: %d", status);
             }
         }
-        else if(gSourceType == 0) {
+        else {
             /*check for sink*/
             UT_ASSERT_EQUAL(status, dsHDCP_STATUS_AUTHENTICATED);
             if (status != dsHDCP_STATUS_AUTHENTICATED) {

--- a/src/test_l2_dsVideoPort.c
+++ b/src/test_l2_dsVideoPort.c
@@ -449,7 +449,7 @@ void test_l2_dsVideoPort_VerifySupportedTvResolutions(void)
         bool isConnected = false;
         ret = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
-            UT_ASSERT_EQUAL(resolutions, 0);
+            UT_ASSERT_EQUAL(resolutions, (int)dsTV_RESOLUTION_480i);
         }
         else {
             UT_ASSERT_EQUAL(resolutions, gDSVideoPortConfiguration[port].Supported_tv_resolutions_capabilities);

--- a/src/test_l2_dsVideoPort.c
+++ b/src/test_l2_dsVideoPort.c
@@ -578,8 +578,6 @@ void test_l2_dsVideoPort_GetHDCPStatus(void)
         bool isConnected = false;
         ret = dsIsDisplayConnected(handle, &isConnected);
         if (isConnected){
-            // For vendor image enableHDCP has to be done from code
-            // enableHDCP only if displayconnected is true
             char hdcpKey[HDCP_KEY_MAX_SIZE] = "ADEF";
             int keySize = HDCP_KEY_MAX_SIZE;
             ret = dsEnableHDCP(handle, true, hdcpKey, keySize);
@@ -595,8 +593,8 @@ void test_l2_dsVideoPort_GetHDCPStatus(void)
         UT_LOG_DEBUG("Return status: %d, HDCP Status: %d", ret, status);
 
         if(!isConnected) {
-            UT_ASSERT_TRUE(status == dsHDCP_STATUS_UNPOWERED || status == dsHDCP_STATUS_PORTDISABLED);
-            if (status != dsHDCP_STATUS_UNPOWERED || status != dsHDCP_STATUS_PORTDISABLED) {
+            UT_ASSERT_TRUE(status == dsHDCP_STATUS_UNPOWERED);
+            if (status != dsHDCP_STATUS_UNPOWERED) {
                 UT_LOG_ERROR("HDCP status is not unpowered or portdisabled. Status: %d", status);
             }
         }

--- a/src/test_l2_dsVideoPort.c
+++ b/src/test_l2_dsVideoPort.c
@@ -449,7 +449,7 @@ void test_l2_dsVideoPort_VerifySupportedTvResolutions(void)
         bool isConnected = false;
         ret = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
-            UT_ASSERT_EQUAL(resolutions, (int)dsTV_RESOLUTION_480i);
+            UT_ASSERT_EQUAL(resolutions, (int)dsTV_RESOLUTION_480p);
         }
         else {
             UT_ASSERT_EQUAL(resolutions, gDSVideoPortConfiguration[port].Supported_tv_resolutions_capabilities);
@@ -912,7 +912,7 @@ void test_l2_dsVideoPort_GetColorDepth(void)
         bool isConnected = false;
         ret = dsIsDisplayConnected(handle, &isConnected);
         if(!isConnected) {
-            UT_ASSERT_EQUAL(color_depth, 8);
+            UT_ASSERT_EQUAL(color_depth, DS_VIDEO_PORT_DEFAULT_COLORDEPTH);
         }
         else {
             UT_ASSERT_EQUAL(color_depth, gDSvideoPort_color_depth);


### PR DESCRIPTION

API Name | Test Case / Issue
-- | --
dsGetHDCPStatus | Test case line 2035 is wrong â€“ should be tested against dcpStatus1, dsHDCP_STATUS_AUTHENTICATED
dsGetTVHDRCapabilities | Depends on TV capabilities
dsSupportedTvResolutions | Depends on TV
dsSetForceDisable4KSupport | Handle check is needed ?, even if not supported
dsGetColorDepth | Depends on TV

</span>

For all these TV api modified the check for the display connected and the ASSERT accordingly. 

