### PR TITLE
gh #456 dsAudio: L1 test_l1_dsAudio_negative_dsGetAssociatedAudioMixing passing valid parameters for a invalid param check

### DIFF
--- a/src/test_l1_dsAudio.c
+++ b/src/test_l1_dsAudio.c
@@ -8027,7 +8027,7 @@ void test_l1_dsAudio_negative_dsGetAssociatedAudioMixing(void)
         UT_ASSERT_NOT_EQUAL(handle, null_handle);
 
         // Step 05: Call with NULL mixing pointer
-        result = dsGetAssociatedAudioMixing(handle, &mixing);
+        result = dsGetAssociatedAudioMixing(handle, NULL);
         UT_ASSERT_EQUAL(result, dsERR_INVALID_PARAM);
     }
 


### PR DESCRIPTION
L1 test_l1_dsAudio_negative_dsGetAssociatedAudioMixing passing valid parameters for a invalid param check.

[result = dsGetAssociatedAudioMixing(handle, &mixing);](https://github.com/rdkcentral/rdk-halif-test-device_settings/blob/c6b37d505c171e49a4baa4f58aa39c2df6adc03a/src/test_l1_dsAudio.c#L8030)

should pass a invalid parameters.L1 test_l1_dsAudio_negative_dsGetAssociatedAudioMixing passing valid parameters for a invalid param check.