### PR TITLE
gh #476 Update MS12_Capabilities in Source_AudioSettings.yaml

### DIFF
--- a/profiles/source/Source_AudioSettings.yaml
+++ b/profiles/source/Source_AudioSettings.yaml
@@ -102,7 +102,7 @@ dsAudio:
             # dsMS12SUPPORT_GraphicEqualizer = (1 << 9),       ///< MS12 Graphic equalizer
             # dsMS12SUPPORT_LEConfig         = (1 << 10),      ///< MS12 LE config
             # dsMS12SUPPORT_Invalid = (1 << 31)                ///< Invalid / Out of range
-            MS12_Capabilities: 0x4D  # DolbyVolume | DialogueEnhancer | Volumeleveller | DRCMode
+            MS12_Capabilities: 0x0C # DialogueEnhancer | Volumeleveller
             MS12_AudioProfiles:
             # number of counts from the "ms12_audio_profiles.ini" file
             MS12_AudioProfileCount: 0


### PR DESCRIPTION
Reason for change: Update the MS12 capabilities so that they appropriately reflect the expectations we have for source devices. Source devices should support dsMS12SUPPORT_DialogueEnhancer and dsMS12SUPPORT_Volumeleveller.

Fixes #476