### PR TITLE
PR: gh #485 :Fixing the decode byte error by initializing the local vars

### DIFF
--- a/src/test_l2_dsAudio.c
+++ b/src/test_l2_dsAudio.c
@@ -2193,7 +2193,7 @@ void test_l2_dsAudio_SetAndGetPrimaryLanguage(void)
     dsError_t ret;
     intptr_t handle;
     const char* setLang = "eng";
-    char getLang[4];
+    char getLang[4] = {0};
 
     UT_LOG_DEBUG("Invoking dsAudioPortInit()");
     ret = dsAudioPortInit();
@@ -2249,7 +2249,7 @@ void test_l2_dsAudio_SetAndGetSecondaryLanguage(void)
     dsError_t ret;
     intptr_t handle;
     const char* setLang = "eng";
-    char getLang[4];
+    char getLang[4] = {0};
 
     UT_LOG_DEBUG("Invoking dsAudioPortInit");
     ret = dsAudioPortInit();


### PR DESCRIPTION
Fixing the decode byte error


🔍 The Problematic Byte:
The byte \xb6 at position 1316 is not a valid starting byte in UTF-8. UTF-8 expects certain patterns for multi-byte characters, and \xb6 alone doesn't match any valid start sequence.

📍 Location in Context:
This appears in the line:

`Return status: 0, Language: eng\xb607\xf8\xbe`
This suggests that the string "Language: eng\xb607\xf8\xbe" contains non-UTF-8 binary data or corrupted encoding after "eng" — possibly a memory address, binary blob, or a misencoded string.