### PR TITLE
gh515 Add dsHost HAL init/term to SOB test suite

### DIFF
--- a/src/test_l3_dsHost.c
+++ b/src/test_l3_dsHost.c
@@ -313,8 +313,11 @@ int test_l3_dsHost_register(void)
     UT_add_test( pSuite, "Initialize dsHost", test_l3_dsHost_hal_Init);
     UT_add_test( pSuite, "Get CPU Temperature", test_l3_dsHost_hal_get_Temperature);
     UT_add_test( pSuite, "Get SoC ID", test_l3_dsHost_hal_get_SocID);
-    UT_add_test( pSuite_SOB_Only, "Get Host EDID", test_l3_dsHost_hal_get_hostEdid);
     UT_add_test( pSuite, "Terminate dsHost", test_l3_dsHost_hal_Term);
+
+    UT_add_test( pSuite_SOB_Only, "Initialize dsHost", test_l3_dsHost_hal_Init);
+    UT_add_test( pSuite_SOB_Only, "Get Host EDID", test_l3_dsHost_hal_get_hostEdid);
+    UT_add_test( pSuite_SOB_Only, "Terminate dsHost", test_l3_dsHost_hal_Term);
 
     return 0;
 }


### PR DESCRIPTION
test_l3_dsHost_hal_get_hostEdid is the only test in the SOB_Only test suite, but it needs to be called after dsHostInit() and before dsHostTerm(), otherwise it will return dsERR_NOT_INITIALIZED, and the test will fail. So add test_l3_dsHost_hal_Init and test_l3_dsHost_hal_Term to the SOB_Only test suite.