### PR TITLE
PR : gh #527 : Fix asserts and modify to UT_ASSERT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ TARGET_EXEC :=hal_test_$(HAL_LIB)
 # Export the tag version
 VERSION := $(shell git describe --tags | head -n1)
 KCFLAGS := -D HALIF_TEST_TAG_VERSION=\"$(VERSION)\"
+KCFLAGS += -DNDEBUG
 
 # Check if TARGET is unset
 ifeq ($(TARGET),)

--- a/src/test_l3_dsAudio.c
+++ b/src/test_l3_dsAudio.c
@@ -87,7 +87,7 @@
 
 #define UT_LOG_MENU_INFO UT_LOG_INFO
 
-#define DS_ASSERT assert
+#define DS_ASSERT UT_ASSERT
 
 #define DS_CONNECTION_CB_FILE "dsAudio_connection_callback.txt"
 #define DS_FORMAT_CB_FILE "dsAudio_format_callback.txt"

--- a/src/test_l3_dsCompositeIn.c
+++ b/src/test_l3_dsCompositeIn.c
@@ -79,7 +79,7 @@
 #include "test_parse_configuration.h"
 #include "dsCompositeIn.h"
 
-#define ASSERT assert
+#define ASSERT UT_ASSERT
 
 /* Global Variables */
 static int32_t gTestGroup = 3;

--- a/src/test_l3_dsCompositeIn.c
+++ b/src/test_l3_dsCompositeIn.c
@@ -79,7 +79,7 @@
 #include "test_parse_configuration.h"
 #include "dsCompositeIn.h"
 
-#define ASSERT UT_ASSERT
+#define DS_ASSERT UT_ASSERT
 
 /* Global Variables */
 static int32_t gTestGroup = 3;
@@ -276,35 +276,35 @@ void test_l3_CompositeIn_initialize(void)
     UT_LOG_INFO("Calling dsCompositeInInit()");
     ret = dsCompositeInInit(); 
     UT_LOG_INFO("Result dsCompositeInInit() dsError_t:[%s]", UT_Control_GetMapString(dsError_mapTable, ret));
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     /* Register connection status callback */
     UT_LOG_INFO("Calling dsCompositeInRegisterConnectCB(IN:CBFunc:[0x%0X])", compositeInConnectCB);
     ret = dsCompositeInRegisterConnectCB(compositeInConnectCB);
     UT_LOG_INFO("Result dsCompositeInRegisterConnectCB(IN:CBFunc:[0x%0X]) dsError_t:[%s]",
                         compositeInConnectCB, UT_Control_GetMapString(dsError_mapTable, ret));
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     /* Register Signal change callback */
     UT_LOG_INFO("Calling dsCompositeInRegisterSignalChangeCB(IN:CBFunc:[0x%0X])", compositeInSignalChangeCB);
     ret = dsCompositeInRegisterSignalChangeCB(compositeInSignalChangeCB);
     UT_LOG_INFO("Result dsCompositeInRegisterSignalChangeCB(IN:CBFunc:[0x%0X]) dsError_t:[%s]",
                         compositeInSignalChangeCB, UT_Control_GetMapString(dsError_mapTable, ret));
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     /* Register Status change callback */
     UT_LOG_INFO("Calling dsCompositeInRegisterStatusChangeCB(IN:CBFunc:[0x%0X])", compositeInStatusChangeCB);
     ret = dsCompositeInRegisterStatusChangeCB(compositeInStatusChangeCB);
     UT_LOG_INFO("Result dsCompositeInRegisterStatusChangeCB(IN:CBFunc:[0x%0X]) dsError_t:[%s]",
                         compositeInStatusChangeCB, UT_Control_GetMapString(dsError_mapTable, ret));
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     /* Register videomode change callback */
     UT_LOG_INFO("Calling dsCompositeInRegisterVideoModeUpdateCB(IN:CBFunc:[0x%0X])", compositeInVideoModeChangeCB);
     ret = dsCompositeInRegisterVideoModeUpdateCB(compositeInVideoModeChangeCB);
     UT_LOG_INFO("Result dsCompositeInRegisterVideoModeUpdateCB(IN:CBFunc:[0x%0X]) dsError_t:[%s]",
                         compositeInVideoModeChangeCB, UT_Control_GetMapString(dsError_mapTable, ret));
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     UT_LOG_INFO("Out %s", __FUNCTION__);
 }
@@ -336,7 +336,7 @@ void test_l3_CompositeIn_get_status(void)
                 UT_Control_GetMapString(bool_mapTable, inputstatus.isPortConnected[i]),
                 UT_Control_GetMapString(dsCompositeInPortMappingTable, inputstatus.activePort));
     }
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     UT_LOG_INFO("Out %s", __FUNCTION__);
 }
@@ -386,7 +386,7 @@ void test_l3_CompositeIn_select_port(void)
     UT_LOG_INFO("Result dsCompositeInSelectPort(IN:port[%s] dsError_t:[%s])",
                 UT_Control_GetMapString(dsCompositeInPortMappingTable, port), 
                 UT_Control_GetMapString(dsError_mapTable, ret));
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     exit:
         UT_LOG_INFO("Out %s", __FUNCTION__);
@@ -469,7 +469,7 @@ void test_l3_CompositeIn_scale_video(void)
     ret = dsCompositeInScaleVideo(x, y, width, height);
     UT_LOG_INFO("Result : dsCompositeInScaleVideo(IN:x[%d], IN:y[%d], IN:width[%d], IN:height[%d]) dsError_t:[%s]",
                 x, y , width, height, UT_Control_GetMapString(dsError_mapTable, ret));
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     exit:
         UT_LOG_INFO("Out %s", __FUNCTION__);
@@ -494,7 +494,7 @@ void test_l3_dsCompositeIn_terminate(void)
     UT_LOG_INFO("Calling dsCompositeInTerm()");
     ret = dsCompositeInTerm();
     UT_LOG_INFO("Result dsCompositeInTerm() dsError_t:[%s]", UT_Control_GetMapString(dsError_mapTable, ret));
-    ASSERT(ret == dsERR_NONE);
+    DS_ASSERT(ret == dsERR_NONE);
 
     UT_LOG_INFO("Out %s", __FUNCTION__);
 }
@@ -511,7 +511,7 @@ int test_l3_dsCompositeIn_register(void)
 {
     // Create the test suite for sink type
     pSuite = UT_add_suite_withGroupID("[L3 dsCompositeIn]", NULL, NULL, UT_TESTS_L3);
-    ASSERT( pSuite != NULL );
+    DS_ASSERT( pSuite != NULL );
 
     UT_add_test( pSuite, "Initialize CompositeIn" ,test_l3_CompositeIn_initialize );
     UT_add_test( pSuite, "Get status of ports" ,test_l3_CompositeIn_get_status );

--- a/src/test_l3_dsDisplay.c
+++ b/src/test_l3_dsDisplay.c
@@ -81,7 +81,7 @@
 #include "test_parse_configuration.h"
 
 #define UT_LOG_MENU_INFO UT_LOG_INFO
-#define DS_ASSERT assert
+#define DS_ASSERT UT_ASSERT
 #define EDID_MAX_DATA_SIZE 256
 #define DS_VIDEO_MAX_INDEX 10
 

--- a/src/test_l3_dsFPD.c
+++ b/src/test_l3_dsFPD.c
@@ -78,7 +78,7 @@
 #include "dsFPD.h"
 
 #define DS_FPD_KEY_SIZE 128
-#define DS_ASSERT assert
+#define DS_ASSERT UT_ASSERT
 #define UT_LOG_MENU_INFO UT_LOG_INFO
 
 static int32_t gTestGroup = 3;

--- a/src/test_l3_dsFPD.c
+++ b/src/test_l3_dsFPD.c
@@ -74,7 +74,6 @@
 #include <ut_log.h>
 #include <ut_kvp_profile.h>
 #include <ut_control_plane.h>
-#include <assert.h>
 #include "dsFPD.h"
 
 #define DS_FPD_KEY_SIZE 128

--- a/src/test_l3_dsHdmiIn.c
+++ b/src/test_l3_dsHdmiIn.c
@@ -77,7 +77,7 @@
 #include <ut_kvp_profile.h>
 #include <ut_control_plane.h>
 
-#define DS_ASSERT assert
+#define DS_ASSERT UT_ASSERT
 #define UT_LOG_MENU_INFO UT_LOG_INFO
 
 /* Global Variables */

--- a/src/test_l3_dsHost.c
+++ b/src/test_l3_dsHost.c
@@ -78,7 +78,7 @@
 #define DSHOST_SOC_LENGTH    20
 #define DS_HOST_KVP_SIZE     128
 
-#define DS_ASSERT assert
+#define DS_ASSERT UT_ASSERT
 
 static int gTestGroup = 3;
 static int gTestID = 1;
@@ -131,7 +131,7 @@ void test_l3_dsHost_hal_Init(void)
     UT_LOG_INFO("Result dsHostInit: dsError_t:[%s]",
                   UT_Control_GetMapString(dsError_mapTable, status));
 
-    assert(status == dsERR_NONE);
+    DS_ASSERT(status == dsERR_NONE);
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -168,7 +168,7 @@ void test_l3_dsHost_hal_get_Temperature(void)
     UT_LOG_INFO("Result dsGetCPUTemperature(cpuTemperature: %f), dsError_t:[%s]",
                   cpuTemperature, UT_Control_GetMapString(dsError_mapTable, status));
 
-    assert(status == dsERR_NONE);
+    DS_ASSERT(status == dsERR_NONE);
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -205,7 +205,7 @@ void test_l3_dsHost_hal_get_SocID(void)
     UT_LOG_INFO("Result dsGetSocIDFromSDK(socID: %s), dsError_t:[%s]",
                   socID,UT_Control_GetMapString(dsError_mapTable, status));
 
-    assert(status == dsERR_NONE);
+    DS_ASSERT(status == dsERR_NONE);
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -243,7 +243,7 @@ void test_l3_dsHost_hal_get_hostEdid(void)
     UT_LOG_INFO("Result dsGetHostEDID(hostEdid[%s], length[%d]), dsError_t:[%s]",
                   hostEdid, length, UT_Control_GetMapString(dsError_mapTable, status));
 
-    assert(status == dsERR_NONE);
+    DS_ASSERT(status == dsERR_NONE);
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -278,7 +278,7 @@ void test_l3_dsHost_hal_Term(void)
     UT_LOG_INFO("Result dsHostTerm() dsError_t:[%s]",
                   UT_Control_GetMapString(dsError_mapTable, status));
 
-    assert(status == dsERR_NONE);
+    DS_ASSERT(status == dsERR_NONE);
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }

--- a/src/test_l3_dsHost.c
+++ b/src/test_l3_dsHost.c
@@ -76,7 +76,7 @@
 #include "test_parse_configuration.h"
 
 #define DSHOST_SOC_LENGTH    20
-#define DS_HOST_KVP_SIZE     128
+#define DS_HOST_EDID_SIZE     1024
 
 #define DS_ASSERT UT_ASSERT
 
@@ -232,8 +232,8 @@ void test_l3_dsHost_hal_get_hostEdid(void)
     gTestID = 4;
     dsError_t status = dsERR_NONE ;
 
-    unsigned char hostEdid[DS_HOST_KVP_SIZE] = {0};
-    int length;
+    unsigned char hostEdid[DS_HOST_EDID_SIZE] = {0};
+    int length = 0;
 
     UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 

--- a/src/test_l3_dsVideoDevice.c
+++ b/src/test_l3_dsVideoDevice.c
@@ -79,7 +79,7 @@
 #include "dsVideoDevice.h"
 
 
-#define DS_ASSERT(actual,expected) assert(actual==expected)
+#define DS_ASSERT(actual,expected) UT_ASSERT(actual==expected)
 #define UT_LOG_MENU_INFO UT_LOG_INFO
 #define DS_FRAMERATE_KEY_SIZE 50
 

--- a/src/test_l3_dsVideoPort.c
+++ b/src/test_l3_dsVideoPort.c
@@ -76,7 +76,6 @@
 #include <ut_kvp_profile.h>
 #include <ut_kvp.h>
 #include <ut_control_plane.h>
-#include <assert.h>
 
 
 #include "dsVideoPort.h"

--- a/src/test_l3_dsVideoPort.c
+++ b/src/test_l3_dsVideoPort.c
@@ -81,7 +81,7 @@
 
 #include "dsVideoPort.h"
 
-#define DS_ASSERT assert
+#define DS_ASSERT UT_ASSERT
 
 intptr_t gHandle = 0;
 


### PR DESCRIPTION
This PR aligns the L3 Device Settings HAL tests with the UT testing framework by replacing direct use of the C assert macro with UT_ASSERT-based macros, and globally disables standard C assertions at build time.

Changes:

- Updated L3 test files to use DS_ASSERT/ASSERT macros mapped to UT_ASSERT instead of the C library assert.
- Replaced inline assert(status == dsERR_NONE) usages in test_l3_dsHost.c with DS_ASSERT(...) that now map to UT_ASSERT.
- Modified the top-level Makefile to add -DNDEBUG to KCFLAGS, disabling standard C assert in builds.