### PR TITLE
gh #512 updated L1 interlaced param

### DIFF
--- a/src/test_l1_dsVideoPort.c
+++ b/src/test_l1_dsVideoPort.c
@@ -1593,7 +1593,7 @@ void test_l1_dsVideoPort_negative_dsSetResolution(void) {
         resolutions.aspectRatio = dsVIDEO_ASPECT_RATIO_MAX;
         resolutions.stereoScopicMode = dsVIDEO_SSMODE_MAX;
         resolutions.frameRate = dsVIDEO_FRAMERATE_MAX;
-        resolutions.interlaced = dsVIDEO_SCANMODE_PROGRESSIVE;
+        resolutions.interlaced = dsVIDEO_SCANMODE_MAX;
         status = dsSetResolution(handle, &resolutions);
         UT_ASSERT_EQUAL(status, dsERR_INVALID_PARAM);
     }


### PR DESCRIPTION
The L1 test case dsSetResolution_neg does not correctly validate the interlaced parameter in the dsSetResolution HAL API. Instead of using an invalid scan mode, it sets dsVIDEO_SCANMODE_PROGRESSIVE, which is valid according to the macro dsVideoPortScanMode_isValid. As a result, the API does not return the expected dsERR_INVALID_PARAM error.

VTS Version: 6.0.0