### PR TITLE
gh #517 dsSetDisplayframerate_positive testcase doesnot validate for source devices in latest version

### DIFF
--- a/src/test_l1_dsVideoDevice.c
+++ b/src/test_l1_dsVideoDevice.c
@@ -1735,14 +1735,14 @@ void test_l1_dsVideoDevice_positive_dsSetDisplayframerate(void)
             break;
 
         // Step 03: Set the display framerate using the obtained handle
-        for(int j=0;j<gDSVideoDeviceConfiguration[i].NoOfSupportedDFR;j++){
-            result = dsSetDisplayframerate(handle, gDSVideoDeviceConfiguration[i].SupportedDisplayFramerate[j]);
-            if(gSourceType == 0) {
+        if(gSourceType == 0) {
+            for(int j=0;j<gDSVideoDeviceConfiguration[i].NoOfSupportedDFR;j++){
+                result = dsSetDisplayframerate(handle, gDSVideoDeviceConfiguration[i].SupportedDisplayFramerate[j]);
                 UT_ASSERT_EQUAL(result, dsERR_NONE);
-            } else if(gSourceType == 1){
-                // Step 04: API is not supported on source devices
-                UT_ASSERT_EQUAL(result, dsERR_OPERATION_NOT_SUPPORTED);
             }
+        } else if(gSourceType == 1){
+            result = dsSetDisplayframerate(handle, gDSVideoDeviceConfiguration[0].SupportedDisplayFramerate[0]);
+            UT_ASSERT_EQUAL(result, dsERR_OPERATION_NOT_SUPPORTED);
         }
     }
 


### PR DESCRIPTION
for halif-test version :6.0.0

In test_l1_dsVideoDevice_positive_dsSetDisplayframerate

For source devices --> NoOfSupportedDFR is set as 0
so loop is not executed even once
hence else if(gSourceType == 1) condition is not validated at all
dsSetDisplayframerate must be validated for source device as well
